### PR TITLE
Update Piscina Moisés landing page

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -73,9 +73,32 @@ section {
 }
 
 .hero__subtitle {
-  max-width: 520px;
+  max-width: 620px;
   color: var(--color-muted);
   margin-bottom: 2rem;
+}
+
+.hero__list {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0 0 2.5rem;
+  padding: 0;
+  list-style: none;
+  color: var(--color-text);
+}
+
+.hero__list li {
+  display: flex;
+  gap: 0.65rem;
+  align-items: flex-start;
+  font-weight: 500;
+}
+
+.hero__list li::before {
+  content: '▹';
+  color: var(--color-accent);
+  font-size: 1rem;
+  transform: translateY(0.15rem);
 }
 
 .hero__actions {
@@ -201,6 +224,31 @@ section {
   font-size: 1.75rem;
 }
 
+.highlights__grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.highlight-card {
+  background: linear-gradient(160deg, rgba(16, 44, 67, 0.9), rgba(6, 19, 32, 0.9));
+  border-radius: 20px;
+  padding: 2.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.28);
+  display: grid;
+  gap: 1rem;
+}
+
+.highlight-card h3 {
+  margin: 0;
+}
+
+.highlight-card p {
+  color: var(--color-muted);
+  margin: 0;
+}
+
 .cta {
   display: grid;
   gap: 2rem;
@@ -318,6 +366,15 @@ textarea:focus {
 }
 
 @media (max-width: 640px) {
+  .hero {
+    padding: 5rem 1.25rem;
+    min-height: auto;
+  }
+
+  .hero__list {
+    margin-bottom: 2rem;
+  }
+
   .hero__badge {
     width: 100%;
     align-items: center;

--- a/app/page.js
+++ b/app/page.js
@@ -1,51 +1,71 @@
 const services = [
   {
-    title: 'Reparación integral',
+    title: 'Mantenimiento de piscinas',
     description:
-      'Localizamos fugas, reparamos grietas y renovamos instalaciones hidráulicas para que tu piscina vuelva a lucir como nueva.'
+      'Planes estacionales y anuales con limpieza, control químico y seguimiento digital para comunidades y residencias.'
   },
   {
-    title: 'Mantenimiento completo',
+    title: 'Piscinas proyectadas completas',
     description:
-      'Planes a medida con limpiezas programadas, equilibrado químico y control preventivo para garantizar agua cristalina todo el año.'
+      'Diseñamos y ejecutamos vasos gunitados, instalaciones hidráulicas y acabados decorativos llave en mano.'
   },
   {
-    title: 'Modernización & domótica',
+    title: 'Reformas e impermeabilización',
     description:
-      'Actualizamos iluminación, sistemas de climatización y automatizamos procesos para que disfrutes de tu piscina sin preocupaciones.'
+      'Rehabilitamos estructuras, renovamos coronaciones y aplicamos sistemas de impermeabilización certificados.'
+  },
+  {
+    title: 'Fontanería y equipos de sal',
+    description:
+      'Instalamos cloración salina, bombas de calor y automatizaciones que optimizan el consumo y el confort.'
   }
 ];
 
 const sellingPoints = [
   {
-    label: '20+ años de experiencia local',
-    detail: 'Equipo técnico especializado en piscinas residenciales y comunitarias de la Sierra Oeste.'
+    label: 'Experiencia comprobada',
+    detail: 'Más de 15 años construyendo y cuidando piscinas en Madrid, Toledo y Ávila.'
   },
   {
-    label: 'Respuesta urgente',
-    detail: 'Atención preferente en San Martín de Valdeiglesias con diagnósticos rápidos y presupuestos claros.'
+    label: 'Respuesta en 24 horas',
+    detail: 'Diagnóstico técnico y propuesta clara para que tomes decisiones sin sorpresas.'
   },
   {
-    label: 'Garantía transparente',
-    detail: 'Materiales certificados, mano de obra garantizada y seguimiento post-servicio.'
+    label: 'Garantía Piscina Moisés',
+    detail: 'Materiales homologados, personal propio y servicio posventa con seguimiento continuo.'
   }
 ];
 
 const steps = [
   {
-    title: '1. Visita técnica gratuita',
+    title: '1. Estudio y asesoría personalizada',
     description:
-      'Nos desplazamos a tu piscina, analizamos el estado real y detectamos los puntos críticos.'
+      'Visitamos tu piscina o parcela, analizamos necesidades y definimos el plan de actuación ideal.'
   },
   {
-    title: '2. Propuesta detallada',
+    title: '2. Planificación transparente',
     description:
-      'Recibirás un presupuesto desglosado con opciones de reparación, mejora y mantenimiento.'
+      'Entregamos presupuesto desglosado, calendario de trabajos y propuestas de mejora energética.'
   },
   {
-    title: '3. Ejecución impecable',
+    title: '3. Ejecución certificada',
     description:
-      'Coordinamos al equipo especializado y te mantenemos informado de cada avance hasta la entrega final.'
+      'Coordinamos a nuestro equipo especializado y te mantenemos informado en cada hito hasta la entrega final.'
+  }
+];
+
+const highlights = [
+  {
+    title: 'Cobertura integral',
+    description: 'Servicio oficial en Comunidad de Madrid y provincias limítrofes con soporte de emergencia.'
+  },
+  {
+    title: 'Tecnología y eficiencia',
+    description: 'Equipos de sal, automatización y soluciones de bajo consumo para un agua perfecta todo el año.'
+  },
+  {
+    title: 'Acabados a medida',
+    description: 'Revestimientos vítreos, microcemento, iluminación LED y domótica integrada.'
   }
 ];
 
@@ -55,14 +75,18 @@ export default function HomePage() {
       <section className="hero">
         <div className="hero__overlay" />
         <div className="hero__content">
-          <p className="hero__eyebrow">Servicio premium en San Martín de Valdeiglesias</p>
-          <h1 className="hero__title">
-            Expertos en reparación y mantenimiento de piscinas con resultados de lujo
-          </h1>
+          <p className="hero__eyebrow">𝓟𝓲𝓼𝓬𝓲𝓷𝓪 𝓜𝓸𝓲𝓼𝓮𝓼 · Especialistas en piscinas premium</p>
+          <h1 className="hero__title">Diseñamos, proyectamos y cuidamos piscinas sin límites</h1>
           <p className="hero__subtitle">
-            Recupera la tranquilidad con un equipo de confianza que cuida cada detalle: desde la detección de
-            fugas hasta el mantenimiento integral con tecnología de última generación.
+            Convertimos cada espacio acuático en una experiencia segura y elegante: desde nuevas piscinas proyectadas hasta la
+            renovación total con tecnología de cloración salina.
           </p>
+          <ul className="hero__list">
+            <li>Mantenimiento profesional de piscinas residenciales y comunitarias.</li>
+            <li>Proyección completa de vasos en hormigón gunitado y acabados a medida.</li>
+            <li>Reformas estructurales, impermeabilización avanzada y domótica.</li>
+            <li>Fontanería especializada con equipos de sal y automatización inteligente.</li>
+          </ul>
           <div className="hero__actions">
             <a className="button button--primary" href="#presupuesto">
               Solicitar presupuesto
@@ -72,8 +96,8 @@ export default function HomePage() {
             </a>
           </div>
           <div className="hero__badge">
-            <span className="hero__badge-title">Aquaval Piscinas</span>
-            <span className="hero__badge-text">Cuidamos cada piscina como si fuera nuestra.</span>
+            <span className="hero__badge-title">Equipo certificado</span>
+            <span className="hero__badge-text">Más de 250 proyectos entregados con garantía Piscina Moisés.</span>
           </div>
         </div>
       </section>
@@ -81,10 +105,10 @@ export default function HomePage() {
       <section className="selling-points" id="servicios">
         <div className="section-heading">
           <p className="section-eyebrow">Por qué nos eligen</p>
-          <h2>Calidad artesanal con servicio cercano</h2>
+          <h2>Soluciones integrales y artesanía en cada detalle</h2>
           <p className="section-description">
-            Somos vecinos de San Martín de Valdeiglesias y conocemos a fondo las necesidades de las piscinas en
-            la zona. Nuestro objetivo es que disfrutes sin preocupaciones.
+            Somos una empresa española especializada en piscinas a medida. Coordinamos todas las fases del proyecto para que
+            disfrutes sin preocupaciones, con comunicación directa y tiempos de respuesta inmediatos.
           </p>
         </div>
         <div className="selling-points__grid">
@@ -115,6 +139,25 @@ export default function HomePage() {
         </div>
       </section>
 
+      <section className="highlights">
+        <div className="section-heading">
+          <p className="section-eyebrow">Nuestra forma de trabajar</p>
+          <h2>Expertos en proyectos complejos y mantenimiento continuo</h2>
+          <p className="section-description">
+            Integramos arquitectura, ingeniería y mantenimiento en un mismo equipo. Cada piscina recibe un plan único con
+            inspecciones programadas, informes digitales y recomendaciones para optimizar recursos.
+          </p>
+        </div>
+        <div className="highlights__grid">
+          {highlights.map((highlight) => (
+            <article className="highlight-card" key={highlight.title}>
+              <h3>{highlight.title}</h3>
+              <p>{highlight.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
       <section className="cta">
         <div className="cta__text">
           <p className="section-eyebrow">Piscinas impecables todo el año</p>
@@ -123,8 +166,8 @@ export default function HomePage() {
             <br /> con seguimiento digital
           </h2>
           <p>
-            Recibe informes tras cada visita, controla el estado del agua y confía en un plan diseñado para tu
-            piscina. Nos encargamos de todo para que tú solo tengas que disfrutarla.
+            Recibe informes tras cada visita, controla el estado del agua y confía en un plan diseñado para tu piscina. Nos
+            encargamos de todo para que tú solo tengas que disfrutarla.
           </p>
         </div>
         <ul className="cta__list">
@@ -185,9 +228,10 @@ export default function HomePage() {
               <option value="" disabled>
                 Selecciona una opción
               </option>
-              <option value="reparacion">Reparación integral</option>
-              <option value="mantenimiento">Plan de mantenimiento</option>
-              <option value="modernizacion">Modernización y domótica</option>
+              <option value="mantenimiento">Mantenimiento de piscinas</option>
+              <option value="proyeccion">Piscina proyectada nueva</option>
+              <option value="reforma">Reforma o impermeabilización</option>
+              <option value="fontaneria">Fontanería y cloración salina</option>
               <option value="otro">Otros trabajos</option>
             </select>
           </div>
@@ -208,12 +252,12 @@ export default function HomePage() {
 
       <footer className="footer">
         <div>
-          <strong>Aquaval Piscinas</strong>
-          <p>San Martín de Valdeiglesias · Sierra Oeste de Madrid</p>
+          <strong>Piscina Moisés</strong>
+          <p>Servicio integral · Comunidad de Madrid y provincias colindantes</p>
         </div>
         <div className="footer__contact">
-          <a href="tel:+34910000000">910 000 000</a>
-          <a href="mailto:contacto@aquavalpiscinas.com">contacto@aquavalpiscinas.com</a>
+          <a href="tel:+34911011222">91 101 12 22</a>
+          <a href="mailto:hola@piscinamoises.es">hola@piscinamoises.es</a>
         </div>
       </footer>
     </main>


### PR DESCRIPTION
## Summary
- replace the hero and service content with Piscina Moisés branding and messaging
- add a highlights section and expanded service descriptions for projected pools, mantenimiento, reformas e impermeabilización, and equipos de sal
- extend global styles for the new hero checklist and highlight cards while keeping the layout responsive on mobile

## Testing
- npm install *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7f3c93888332882c4ce29a15913c