### PR TITLE
Add imagery and responsive layout refinements

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -38,12 +38,13 @@ section {
 
 .hero {
   position: relative;
-  min-height: 100vh;
+  min-height: clamp(520px, 75vh, 680px);
   display: grid;
   align-items: center;
-  padding: 6rem 1.5rem;
-  background: linear-gradient(135deg, rgba(6, 10, 31, 0.85), rgba(18, 72, 107, 0.85)),
-    url('https://images.unsplash.com/photo-1505843290829-5ae4f4c17a66?auto=format&fit=crop&w=1600&q=80') center/cover;
+  padding: 5rem 1.5rem;
+  background: radial-gradient(circle at top right, rgba(34, 209, 238, 0.18), transparent 55%),
+    linear-gradient(135deg, rgba(6, 10, 31, 0.95), rgba(18, 72, 107, 0.88));
+  overflow: hidden;
 }
 
 .hero__overlay {
@@ -52,10 +53,17 @@ section {
   background: linear-gradient(120deg, rgba(13, 27, 42, 0.9), rgba(13, 110, 140, 0.7));
 }
 
-.hero__content {
+.hero__inner {
   position: relative;
-  max-width: 800px;
   z-index: 1;
+  display: grid;
+  gap: 3rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.hero__content {
+  max-width: 720px;
 }
 
 .hero__eyebrow {
@@ -127,6 +135,55 @@ section {
 .hero__badge-text {
   font-size: 0.9rem;
   color: var(--color-muted);
+}
+
+.hero__media {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hero__photo {
+  position: relative;
+  overflow: hidden;
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+}
+
+.hero__photo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.hero__photo--primary {
+  min-height: 320px;
+}
+
+.hero__photo-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.hero__note {
+  display: grid;
+  gap: 0.5rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 18px;
+  background: rgba(8, 32, 50, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--color-muted);
+  max-width: 360px;
+  backdrop-filter: blur(10px);
+}
+
+.hero__note span {
+  color: var(--color-accent);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
 }
 
 .button {
@@ -213,15 +270,28 @@ section {
   color: var(--color-muted);
 }
 
-.service-card__icon {
-  width: 56px;
-  height: 56px;
+.service-card {
+  padding: 0;
+  overflow: hidden;
+}
+
+.service-card__media {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+}
+
+.service-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.service-card__content {
   display: grid;
-  place-items: center;
-  background: rgba(34, 209, 238, 0.15);
-  border-radius: 16px;
-  margin-bottom: 1rem;
-  font-size: 1.75rem;
+  gap: 0.75rem;
+  padding: 2rem;
 }
 
 .highlights__grid {
@@ -247,6 +317,38 @@ section {
 .highlight-card p {
   color: var(--color-muted);
   margin: 0;
+}
+
+.gallery__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.gallery__item {
+  display: grid;
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(16, 44, 67, 0.65);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.28);
+}
+
+.gallery__item img {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+  display: block;
+}
+
+.gallery__item figcaption {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1.25rem 1.5rem 1.75rem;
+}
+
+.gallery__item span {
+  color: var(--color-muted);
 }
 
 .cta {
@@ -356,7 +458,7 @@ textarea:focus {
   }
 
   .hero {
-    padding: 8rem 6rem;
+    padding: 6rem 6rem;
   }
 
   .cta {
@@ -365,10 +467,42 @@ textarea:focus {
   }
 }
 
+@media (min-width: 768px) {
+  .hero__inner {
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+    align-items: center;
+  }
+
+  .hero__media {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 0.85fr);
+    align-items: stretch;
+  }
+
+  .hero__photo--primary {
+    min-height: 100%;
+  }
+}
+
 @media (max-width: 640px) {
   .hero {
-    padding: 5rem 1.25rem;
+    padding: 4rem 1.25rem 3.5rem;
     min-height: auto;
+  }
+
+  .hero__inner {
+    gap: 2.5rem;
+  }
+
+  .hero__media {
+    gap: 1rem;
+  }
+
+  .hero__photo {
+    border-radius: 18px;
+  }
+
+  .hero__note {
+    max-width: none;
   }
 
   .hero__list {

--- a/app/page.js
+++ b/app/page.js
@@ -2,22 +2,71 @@ const services = [
   {
     title: 'Mantenimiento de piscinas',
     description:
-      'Planes estacionales y anuales con limpieza, control químico y seguimiento digital para comunidades y residencias.'
+      'Planes estacionales y anuales con limpieza, control químico y seguimiento digital para comunidades y residencias.',
+    image: {
+      src: 'https://images.unsplash.com/photo-1564584217132-2271feaeb3c5?auto=format&fit=crop&w=800&q=80',
+      alt: 'Técnico revisando el estado del agua en una piscina residencial'
+    }
   },
   {
     title: 'Piscinas proyectadas completas',
     description:
-      'Diseñamos y ejecutamos vasos gunitados, instalaciones hidráulicas y acabados decorativos llave en mano.'
+      'Diseñamos y ejecutamos vasos gunitados, instalaciones hidráulicas y acabados decorativos llave en mano.',
+    image: {
+      src: 'https://images.unsplash.com/photo-1505843513577-22bb7d21e455?auto=format&fit=crop&w=800&q=80',
+      alt: 'Piscina de diseño con borde infinito y vistas abiertas'
+    }
   },
   {
     title: 'Reformas e impermeabilización',
     description:
-      'Rehabilitamos estructuras, renovamos coronaciones y aplicamos sistemas de impermeabilización certificados.'
+      'Rehabilitamos estructuras, renovamos coronaciones y aplicamos sistemas de impermeabilización certificados.',
+    image: {
+      src: 'https://images.unsplash.com/photo-1519052537078-e6302a4968d4?auto=format&fit=crop&w=800&q=80',
+      alt: 'Renovación de revestimientos en una piscina familiar'
+    }
   },
   {
     title: 'Fontanería y equipos de sal',
     description:
-      'Instalamos cloración salina, bombas de calor y automatizaciones que optimizan el consumo y el confort.'
+      'Instalamos cloración salina, bombas de calor y automatizaciones que optimizan el consumo y el confort.',
+    image: {
+      src: 'https://images.unsplash.com/photo-1530543787849-128d94430c6b?auto=format&fit=crop&w=800&q=80',
+      alt: 'Cuarto técnico con equipamiento de cloración salina'
+    }
+  }
+];
+
+const projects = [
+  {
+    name: 'Residencial Valdeiglesias',
+    detail: 'Piscina climatizada con cloración salina y domótica integrada.',
+    image: 'https://images.unsplash.com/photo-1540541338287-41700207dee6?auto=format&fit=crop&w=1000&q=80'
+  },
+  {
+    name: 'Hotel Sierra Azul',
+    detail: 'Lámina de agua infinita con iluminación RGB programable.',
+    image: 'https://images.unsplash.com/photo-1506126613408-eca07ce68773?auto=format&fit=crop&w=1000&q=80'
+  },
+  {
+    name: 'Urbanización Montealto',
+    detail: 'Reforma integral y automatización de control químico.',
+    image: 'https://images.unsplash.com/photo-1507502707541-f369a3b18502?auto=format&fit=crop&w=1000&q=80'
+  },
+  {
+    name: 'Vivienda unifamiliar Los Arroyos',
+    detail: 'Microcemento, playa húmeda y jacuzzi integrado.',
+    image: 'https://images.unsplash.com/photo-1516156008625-3a9d6067fab5?auto=format&fit=crop&w=1000&q=80'
+  },
+  {
+    name: 'Comunidad Jardines del Tajo',
+    detail: 'Plan de mantenimiento integral con reportes digitales.',
+    image: 'https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1000&q=80'
+  },
+  {
+    name: 'Club Náutico San Martín',
+    detail: 'Renovación del vaso y sistemas de filtración de alto rendimiento.',
+    image: 'https://images.unsplash.com/photo-1611892440504-42a792e24d32?auto=format&fit=crop&w=1000&q=80'
   }
 ];
 
@@ -74,30 +123,58 @@ export default function HomePage() {
     <main className="page">
       <section className="hero">
         <div className="hero__overlay" />
-        <div className="hero__content">
-          <p className="hero__eyebrow">𝓟𝓲𝓼𝓬𝓲𝓷𝓪 𝓜𝓸𝓲𝓼𝓮𝓼 · Especialistas en piscinas premium</p>
-          <h1 className="hero__title">Diseñamos, proyectamos y cuidamos piscinas sin límites</h1>
-          <p className="hero__subtitle">
-            Convertimos cada espacio acuático en una experiencia segura y elegante: desde nuevas piscinas proyectadas hasta la
-            renovación total con tecnología de cloración salina.
-          </p>
-          <ul className="hero__list">
-            <li>Mantenimiento profesional de piscinas residenciales y comunitarias.</li>
-            <li>Proyección completa de vasos en hormigón gunitado y acabados a medida.</li>
-            <li>Reformas estructurales, impermeabilización avanzada y domótica.</li>
-            <li>Fontanería especializada con equipos de sal y automatización inteligente.</li>
-          </ul>
-          <div className="hero__actions">
-            <a className="button button--primary" href="#presupuesto">
-              Solicitar presupuesto
-            </a>
-            <a className="button button--ghost" href="#servicios">
-              Ver servicios
-            </a>
+        <div className="hero__inner">
+          <div className="hero__content">
+            <p className="hero__eyebrow">𝓟𝓲𝓼𝓬𝓲𝓷𝓪 𝓜𝓸𝓲𝓼𝓮𝓼 · Especialistas en piscinas premium</p>
+            <h1 className="hero__title">Diseñamos, proyectamos y cuidamos piscinas sin límites</h1>
+            <p className="hero__subtitle">
+              Convertimos cada espacio acuático en una experiencia segura y elegante: desde nuevas piscinas proyectadas hasta la
+              renovación total con tecnología de cloración salina.
+            </p>
+            <ul className="hero__list">
+              <li>Mantenimiento profesional de piscinas residenciales y comunitarias.</li>
+              <li>Proyección completa de vasos en hormigón gunitado y acabados a medida.</li>
+              <li>Reformas estructurales, impermeabilización avanzada y domótica.</li>
+              <li>Fontanería especializada con equipos de sal y automatización inteligente.</li>
+            </ul>
+            <div className="hero__actions">
+              <a className="button button--primary" href="#presupuesto">
+                Solicitar presupuesto
+              </a>
+              <a className="button button--ghost" href="#servicios">
+                Ver servicios
+              </a>
+            </div>
+            <div className="hero__badge">
+              <span className="hero__badge-title">Equipo certificado</span>
+              <span className="hero__badge-text">Más de 250 proyectos entregados con garantía Piscina Moisés.</span>
+            </div>
           </div>
-          <div className="hero__badge">
-            <span className="hero__badge-title">Equipo certificado</span>
-            <span className="hero__badge-text">Más de 250 proyectos entregados con garantía Piscina Moisés.</span>
+          <div className="hero__media">
+            <figure className="hero__photo hero__photo--primary">
+              <img
+                src="https://images.unsplash.com/photo-1534536281715-e28d76689b4d?auto=format&fit=crop&w=1000&q=80"
+                alt="Piscina de lujo al atardecer con iluminación ambiental"
+              />
+            </figure>
+            <div className="hero__photo-stack">
+              <figure className="hero__photo">
+                <img
+                  src="https://images.unsplash.com/photo-1531853121101-1b4b07fd4e9e?auto=format&fit=crop&w=700&q=80"
+                  alt="Detalle de cascada en piscina moderna"
+                />
+              </figure>
+              <figure className="hero__photo">
+                <img
+                  src="https://images.unsplash.com/photo-1527515637462-cff94eecc1ac?auto=format&fit=crop&w=700&q=80"
+                  alt="Técnico de piscina realizando comprobaciones de calidad"
+                />
+              </figure>
+            </div>
+            <div className="hero__note">
+              <span>Residencial · Hotelero · Wellness</span>
+              <p>Proyectos personalizados con seguimiento digital desde el diseño hasta el mantenimiento.</p>
+            </div>
           </div>
         </div>
       </section>
@@ -129,11 +206,13 @@ export default function HomePage() {
         <div className="services__grid">
           {services.map((service) => (
             <article className="service-card" key={service.title}>
-              <div className="service-card__icon" aria-hidden="true">
-                <span>💧</span>
+              <div className="service-card__media">
+                <img src={service.image.src} alt={service.image.alt} loading="lazy" />
               </div>
-              <h3>{service.title}</h3>
-              <p>{service.description}</p>
+              <div className="service-card__content">
+                <h3>{service.title}</h3>
+                <p>{service.description}</p>
+              </div>
             </article>
           ))}
         </div>
@@ -154,6 +233,28 @@ export default function HomePage() {
               <h3>{highlight.title}</h3>
               <p>{highlight.description}</p>
             </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="gallery">
+        <div className="section-heading">
+          <p className="section-eyebrow">Casos recientes</p>
+          <h2>Inspiración visual de nuestros proyectos</h2>
+          <p className="section-description">
+            Así combinamos estética, ingeniería y mantenimiento profesional en residencias privadas, hoteles y comunidades de
+            vecinos en la zona centro.
+          </p>
+        </div>
+        <div className="gallery__grid">
+          {projects.map((project) => (
+            <figure className="gallery__item" key={project.name}>
+              <img src={project.image} alt={project.name} loading="lazy" />
+              <figcaption>
+                <strong>{project.name}</strong>
+                <span>{project.detail}</span>
+              </figcaption>
+            </figure>
           ))}
         </div>
       </section>


### PR DESCRIPTION
## Summary
- add a responsive hero layout with dedicated media gallery and supporting note
- include photography for each servicio card and a new inspiration gallery section
- refresh global styles to support the new imagery while reducing the hero height on all devices

## Testing
- npm install *(fails: registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8153cf608332a6931f69e4cdc305