### PR TITLE
Improve mobile navigation and gallery experience

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -29,6 +29,7 @@ body {
   min-height: 100vh;
   position: relative;
   overflow-x: hidden;
+  scroll-padding-top: 84px;
 }
 
 body::before {
@@ -52,8 +53,123 @@ main {
 .page {
   display: flex;
   flex-direction: column;
-  gap: 6rem;
-  padding-bottom: 4rem;
+  gap: 5.5rem;
+  padding: 5.5rem 0 4rem;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  padding: 0.85rem 1.5rem;
+  backdrop-filter: blur(16px);
+  background: rgba(8, 24, 38, 0.85);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.site-header__inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.site-header__brand {
+  font-weight: 700;
+  font-size: 1rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.site-header__nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 1.5rem;
+}
+
+.site-header__nav a {
+  color: var(--color-muted);
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.95rem;
+  transition: color 0.2s ease;
+}
+
+.site-header__nav a:hover,
+.site-header__nav a:focus-visible {
+  color: var(--color-accent);
+}
+
+.site-header__nav--desktop {
+  display: none;
+}
+
+.site-header__nav--mobile {
+  margin-top: 0.75rem;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(8, 32, 50, 0.92);
+  padding: 1.25rem 1.5rem 1.5rem;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+}
+
+.site-header__nav--mobile ul {
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.site-header__menu-button {
+  background: transparent;
+  border: none;
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-end;
+  gap: 0.35rem;
+  padding: 0.35rem 0;
+  cursor: pointer;
+}
+
+.site-header__menu-button span {
+  display: block;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--color-text);
+  transition: width 0.2s ease;
+}
+
+.site-header__menu-button span:nth-child(1) {
+  width: 24px;
+}
+
+.site-header__menu-button span:nth-child(2) {
+  width: 18px;
+}
+
+.site-header__menu-button span:nth-child(3) {
+  width: 28px;
+}
+
+.site-header__menu-button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 4px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
 section {
@@ -108,15 +224,21 @@ section {
   position: relative;
   z-index: 1;
   display: grid;
-  gap: 3rem;
-  max-width: 1200px;
+  gap: 2.5rem;
+  max-width: 880px;
   margin: 0 auto;
+  justify-items: start;
 }
 
 .hero__content {
-  max-width: 720px;
+  max-width: 640px;
   display: grid;
-  gap: 1.5rem;
+  gap: 1.35rem;
+  padding: 2.25rem 2.5rem;
+  background: rgba(8, 32, 50, 0.7);
+  border-radius: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
 }
 
 .hero__eyebrow {
@@ -172,15 +294,15 @@ section {
 }
 
 .hero__badge {
-  margin-top: 3rem;
+  margin-top: 2.5rem;
   display: inline-flex;
   flex-direction: column;
   gap: 0.25rem;
   padding: 1rem 1.5rem;
   border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 999px;
+  border-radius: 18px;
   backdrop-filter: blur(12px);
-  background: rgba(16, 44, 67, 0.65);
+  background: rgba(16, 44, 67, 0.6);
 }
 
 .hero__badge-title {
@@ -191,55 +313,6 @@ section {
 .hero__badge-text {
   font-size: 0.9rem;
   color: var(--color-muted);
-}
-
-.hero__media {
-  display: grid;
-  gap: 1.5rem;
-}
-
-.hero__photo {
-  position: relative;
-  overflow: hidden;
-  border-radius: 24px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.4);
-}
-
-.hero__photo img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
-
-.hero__photo--primary {
-  min-height: 320px;
-}
-
-.hero__photo-stack {
-  display: grid;
-  gap: 1rem;
-}
-
-.hero__note {
-  display: grid;
-  gap: 0.5rem;
-  padding: 1.25rem 1.5rem;
-  border-radius: 18px;
-  background: rgba(8, 32, 50, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  color: var(--color-muted);
-  max-width: 360px;
-  backdrop-filter: blur(10px);
-}
-
-.hero__note span {
-  color: var(--color-accent);
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-size: 0.75rem;
 }
 
 .button {
@@ -387,35 +460,95 @@ section {
 
 .gallery__grid {
   display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
-.gallery__item {
+.project-card {
   display: grid;
-  border-radius: 20px;
+  gap: 1.5rem;
+  background: linear-gradient(150deg, rgba(16, 44, 67, 0.92), rgba(8, 26, 41, 0.9));
+  border-radius: 22px;
+  padding: 1.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.32);
+}
+
+.project-card__header {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.project-card__header strong {
+  font-size: 1.1rem;
+}
+
+.project-card__header span {
+  color: var(--color-muted);
+}
+
+.project-card__carousel {
+  display: grid;
+  gap: 1rem;
+}
+
+.project-card__viewport {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  padding-bottom: 0.25rem;
+}
+
+.project-card__viewport::-webkit-scrollbar {
+  display: none;
+}
+
+.project-card__slide {
+  position: relative;
+  min-width: 80%;
+  border-radius: 18px;
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(16, 44, 67, 0.7);
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3);
-  transition: transform 0.4s ease, box-shadow 0.4s ease;
+  scroll-snap-align: start;
+  background: rgba(9, 28, 45, 0.8);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.32);
 }
 
-.gallery__item img {
+.project-card__slide img {
   width: 100%;
   height: 220px;
   object-fit: cover;
   display: block;
 }
 
-.gallery__item figcaption {
-  display: grid;
-  gap: 0.35rem;
-  padding: 1.25rem 1.5rem 1.75rem;
+.project-card__controls {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
 }
 
-.gallery__item span {
-  color: var(--color-muted);
+.project-card__control {
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(8, 32, 50, 0.8);
+  color: var(--color-text);
+  font-size: 1.4rem;
+  line-height: 1;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.project-card__control:hover,
+.project-card__control:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(15, 176, 206, 0.25);
+  outline: none;
 }
 
 .cta {
@@ -551,21 +684,27 @@ textarea:focus {
     grid-template-columns: 1.1fr 0.9fr;
     padding: 5rem 6rem;
   }
+
+  .project-card__slide {
+    min-width: 55%;
+  }
 }
 
 @media (min-width: 768px) {
-  .hero__inner {
-    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
-    align-items: center;
+  .site-header__nav--desktop {
+    display: block;
   }
 
-  .hero__media {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 0.85fr);
-    align-items: stretch;
+  .site-header__menu-button {
+    display: none;
   }
 
-  .hero__photo--primary {
-    min-height: 100%;
+  .hero__content {
+    padding: 3rem 3.25rem;
+  }
+
+  .project-card__slide {
+    min-width: 60%;
   }
 }
 
@@ -576,19 +715,8 @@ textarea:focus {
   }
 
   .hero__inner {
-    gap: 2.5rem;
-  }
-
-  .hero__media {
-    gap: 1rem;
-  }
-
-  .hero__photo {
-    border-radius: 18px;
-  }
-
-  .hero__note {
-    max-width: none;
+    gap: 2rem;
+    justify-items: stretch;
   }
 
   .hero__list {
@@ -597,11 +725,15 @@ textarea:focus {
 
   .hero__badge {
     width: 100%;
-    align-items: center;
-    border-radius: 24px;
+    align-items: flex-start;
+    border-radius: 20px;
   }
 
   .contact__form {
     padding: 2rem;
+  }
+
+  .project-card__slide {
+    min-width: 85%;
   }
 }

--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,7 @@
 'use client';
 
-import { motion } from 'framer-motion';
+import { useEffect, useRef, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
 
 const services = [
   {
@@ -45,33 +46,99 @@ const projects = [
   {
     name: 'Residencial Valdeiglesias',
     detail: 'Piscina climatizada con cloración salina y domótica integrada.',
-    image: 'https://images.unsplash.com/photo-1540541338287-41700207dee6?auto=format&fit=crop&w=1000&q=80'
+    images: [
+      {
+        src: 'https://images.unsplash.com/photo-1540541338287-41700207dee6?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Piscina climatizada con cubierta integrada'
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1563911302283-d2bc129e7570?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Detalle de iluminación nocturna en piscina climatizada'
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Zona wellness contigua a piscina climatizada'
+      }
+    ]
   },
   {
     name: 'Hotel Sierra Azul',
     detail: 'Lámina de agua infinita con iluminación RGB programable.',
-    image: 'https://images.unsplash.com/photo-1506126613408-eca07ce68773?auto=format&fit=crop&w=1000&q=80'
+    images: [
+      {
+        src: 'https://images.unsplash.com/photo-1506126613408-eca07ce68773?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Piscina infinita de hotel con vistas a la montaña'
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1505761671935-60b3a7427bad?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Piscina infinita al atardecer con luces encendidas'
+      }
+    ]
   },
   {
     name: 'Urbanización Montealto',
     detail: 'Reforma integral y automatización de control químico.',
-    image: 'https://images.unsplash.com/photo-1507502707541-f369a3b18502?auto=format&fit=crop&w=1000&q=80'
+    images: [
+      {
+        src: 'https://images.unsplash.com/photo-1507502707541-f369a3b18502?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Piscina reformada en urbanización con borde ancho'
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1500929426704-2211a46a1c38?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Detalle de jacuzzi integrado junto a piscina comunitaria'
+      }
+    ]
   },
   {
     name: 'Vivienda unifamiliar Los Arroyos',
     detail: 'Microcemento, playa húmeda y jacuzzi integrado.',
-    image: 'https://images.unsplash.com/photo-1516156008625-3a9d6067fab5?auto=format&fit=crop&w=1000&q=80'
+    images: [
+      {
+        src: 'https://images.unsplash.com/photo-1516156008625-3a9d6067fab5?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Piscina privada con revestimiento en microcemento'
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1504149212288-9571d7108010?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Zona de relax con jacuzzi integrado en piscina'
+      }
+    ]
   },
   {
     name: 'Comunidad Jardines del Tajo',
     detail: 'Plan de mantenimiento integral con reportes digitales.',
-    image: 'https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1000&q=80'
+    images: [
+      {
+        src: 'https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Piscina comunitaria rodeada de vegetación'
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Zona infantil en piscina comunitaria'
+      }
+    ]
   },
   {
     name: 'Club Náutico San Martín',
     detail: 'Renovación del vaso y sistemas de filtración de alto rendimiento.',
-    image: 'https://images.unsplash.com/photo-1611892440504-42a792e24d32?auto=format&fit=crop&w=1000&q=80'
+    images: [
+      {
+        src: 'https://images.unsplash.com/photo-1611892440504-42a792e24d32?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Piscina exterior junto a club náutico'
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1517832207067-4db24a2ae47c?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Zona de nado deportivo en piscina del club'
+      }
+    ]
   }
+];
+
+const navLinks = [
+  { href: '#inicio', label: 'Inicio' },
+  { href: '#servicios', label: 'Servicios' },
+  { href: '#proyectos', label: 'Proyectos' },
+  { href: '#proceso', label: 'Proceso' },
+  { href: '#presupuesto', label: 'Contacto' }
 ];
 
 const sellingPoints = [
@@ -168,11 +235,6 @@ const fadeListItem = {
   }
 };
 
-const mediaReveal = {
-  hidden: { opacity: 0, scale: 0.92 },
-  visible: { opacity: 1, scale: 1, transition: { duration: 0.8, ease: 'easeOut' } }
-};
-
 const cardReveal = {
   hidden: { opacity: 0, y: 26 },
   visible: (index = 0) => ({
@@ -197,10 +259,133 @@ const inViewConfig = {
   viewport: { once: true, amount: 0.2 }
 };
 
-export default function HomePage() {
+const mobileMenu = {
+  hidden: { opacity: 0, y: -16 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, y: -12, transition: { duration: 0.2, ease: 'easeIn' } }
+};
+
+function ProjectCarousel({ project, index }) {
+  const scrollRef = useRef(null);
+
+  const handleScroll = (direction) => {
+    if (!scrollRef.current) return;
+    const distance = scrollRef.current.clientWidth * 0.9;
+    scrollRef.current.scrollBy({ left: direction * distance, behavior: 'smooth' });
+  };
+
+  const hasMultipleImages = project.images.length > 1;
+
   return (
-    <main className="page">
-      <motion.section className="hero" initial="hidden" animate="visible" variants={sectionFade}>
+    <motion.article
+      className="project-card"
+      variants={cardReveal}
+      custom={index}
+      whileHover={{ y: -6, boxShadow: '0 24px 60px rgba(0, 0, 0, 0.35)' }}
+    >
+      <div className="project-card__header">
+        <strong>{project.name}</strong>
+        <span>{project.detail}</span>
+      </div>
+      <div className="project-card__carousel">
+        <div className="project-card__viewport" ref={scrollRef}>
+          {project.images.map((image) => (
+            <div className="project-card__slide" key={image.src}>
+              <img src={image.src} alt={image.alt} loading="lazy" />
+            </div>
+          ))}
+        </div>
+        {hasMultipleImages && (
+          <div className="project-card__controls">
+            <button
+              type="button"
+              className="project-card__control"
+              onClick={() => handleScroll(-1)}
+              aria-label={`Ver imagen anterior de ${project.name}`}
+            >
+              ‹
+            </button>
+            <button
+              type="button"
+              className="project-card__control"
+              onClick={() => handleScroll(1)}
+              aria-label={`Ver imagen siguiente de ${project.name}`}
+            >
+              ›
+            </button>
+          </div>
+        )}
+      </div>
+    </motion.article>
+  );
+}
+
+export default function HomePage() {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    document.body.style.overflow = menuOpen ? 'hidden' : '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [menuOpen]);
+
+  const closeMenu = () => setMenuOpen(false);
+
+  return (
+    <>
+      <motion.header className="site-header" initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }}>
+        <div className="site-header__inner">
+          <a className="site-header__brand" href="#inicio">
+            Piscina Moisés
+          </a>
+          <nav className="site-header__nav site-header__nav--desktop">
+            <ul>
+              {navLinks.map((link) => (
+                <li key={link.href}>
+                  <a href={link.href}>{link.label}</a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+          <button
+            className="site-header__menu-button"
+            type="button"
+            onClick={() => setMenuOpen((prev) => !prev)}
+            aria-expanded={menuOpen}
+            aria-controls="mobile-menu"
+          >
+            <span />
+            <span />
+            <span />
+            <span className="sr-only">Abrir o cerrar menú</span>
+          </button>
+        </div>
+        <AnimatePresence>
+          {menuOpen && (
+            <motion.nav
+              id="mobile-menu"
+              className="site-header__nav site-header__nav--mobile"
+              variants={mobileMenu}
+              initial="hidden"
+              animate="visible"
+              exit="exit"
+            >
+              <ul>
+                {navLinks.map((link) => (
+                  <li key={link.href}>
+                    <a href={link.href} onClick={closeMenu}>
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </motion.nav>
+          )}
+        </AnimatePresence>
+      </motion.header>
+      <main className="page">
+        <motion.section className="hero" id="inicio" initial="hidden" animate="visible" variants={sectionFade}>
         <div className="hero__overlay" />
         <div className="hero__light hero__light--one" aria-hidden />
         <div className="hero__light hero__light--two" aria-hidden />
@@ -249,39 +434,6 @@ export default function HomePage() {
             <motion.div className="hero__badge" variants={fadeUp}>
               <span className="hero__badge-title">Equipo certificado</span>
               <span className="hero__badge-text">Más de 250 proyectos entregados con garantía Piscina Moisés.</span>
-            </motion.div>
-          </motion.div>
-          <motion.div className="hero__media" variants={heroContent}>
-            <motion.figure
-              className="hero__photo hero__photo--primary"
-              variants={mediaReveal}
-              whileHover={{ y: -10, scale: 1.02 }}
-            >
-              <motion.img
-                src="https://images.unsplash.com/photo-1534536281715-e28d76689b4d?auto=format&fit=crop&w=1000&q=80"
-                alt="Piscina de lujo al atardecer con iluminación ambiental"
-                loading="lazy"
-              />
-            </motion.figure>
-            <motion.div className="hero__photo-stack" variants={mediaReveal}>
-              <motion.figure className="hero__photo" variants={mediaReveal} whileHover={{ y: -8, scale: 1.02 }}>
-                <motion.img
-                  src="https://images.unsplash.com/photo-1531853121101-1b4b07fd4e9e?auto=format&fit=crop&w=700&q=80"
-                  alt="Detalle de cascada en piscina moderna"
-                  loading="lazy"
-                />
-              </motion.figure>
-              <motion.figure className="hero__photo" variants={mediaReveal} whileHover={{ y: -8, scale: 1.02 }}>
-                <motion.img
-                  src="https://images.unsplash.com/photo-1527515637462-cff94eecc1ac?auto=format&fit=crop&w=700&q=80"
-                  alt="Técnico de piscina realizando comprobaciones de calidad"
-                  loading="lazy"
-                />
-              </motion.figure>
-            </motion.div>
-            <motion.div className="hero__note" variants={fadeUp}>
-              <span>Residencial · Hotelero · Wellness</span>
-              <p>Proyectos personalizados con seguimiento digital desde el diseño hasta el mantenimiento.</p>
             </motion.div>
           </motion.div>
         </motion.div>
@@ -357,7 +509,7 @@ export default function HomePage() {
         </div>
       </motion.section>
 
-      <motion.section className="gallery" {...inViewConfig} variants={sectionFade}>
+      <motion.section className="gallery" id="proyectos" {...inViewConfig} variants={sectionFade}>
         <motion.div className="section-heading" variants={fadeUp}>
           <p className="section-eyebrow">Casos recientes</p>
           <h2>Inspiración visual de nuestros proyectos</h2>
@@ -368,19 +520,7 @@ export default function HomePage() {
         </motion.div>
         <div className="gallery__grid">
           {projects.map((project, index) => (
-            <motion.figure
-              className="gallery__item"
-              key={project.name}
-              variants={cardReveal}
-              custom={index}
-              whileHover={{ y: -10, scale: 1.01 }}
-            >
-              <motion.img src={project.image} alt={project.name} loading="lazy" />
-              <figcaption>
-                <strong>{project.name}</strong>
-                <span>{project.detail}</span>
-              </figcaption>
-            </motion.figure>
+            <ProjectCarousel key={project.name} project={project} index={index} />
           ))}
         </div>
       </motion.section>
@@ -420,7 +560,7 @@ export default function HomePage() {
         </motion.ul>
       </motion.section>
 
-      <motion.section className="process" {...inViewConfig} variants={sectionFade}>
+      <motion.section className="process" id="proceso" {...inViewConfig} variants={sectionFade}>
         <motion.div className="section-heading" variants={fadeUp}>
           <p className="section-eyebrow">Así trabajamos</p>
           <h2>Un proceso claro, eficiente y sin sorpresas</h2>
@@ -494,6 +634,7 @@ export default function HomePage() {
           <a href="mailto:hola@piscinamoises.es">hola@piscinamoises.es</a>
         </div>
       </motion.footer>
-    </main>
+      </main>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add a sticky header with quick navigation links and an animated mobile menu
- streamline the hero to focus on messaging and CTAs while improving mobile spacing
- turn the project gallery into a horizontal carousel that supports multiple images per proyecto

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd8e714cdc8332adfbdb487721c9f4