### PR TITLE
Restyle landing page to mirror reference design

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,13 +1,20 @@
 :root {
   color-scheme: light;
-  --color-background: #0d1b2a;
-  --color-surface: #102c43;
-  --color-surface-strong: #163b5b;
-  --color-accent: #22d1ee;
-  --color-accent-strong: #0fb0ce;
-  --color-text: #f4f8fb;
-  --color-muted: #c1d2e4;
-  --font-sans: 'Poppins', 'Segoe UI', sans-serif;
+  --color-background: #f4f8fc;
+  --color-surface: #ffffff;
+  --color-surface-soft: #eef4fb;
+  --color-primary: #0d8cd0;
+  --color-primary-strong: #086da8;
+  --color-primary-soft: #14b4e6;
+  --color-text: #0f1f33;
+  --color-muted: #4a6079;
+  --color-border: rgba(15, 31, 51, 0.1);
+  --shadow-soft: 0 24px 60px rgba(15, 64, 109, 0.12);
+  --shadow-strong: 0 32px 80px rgba(11, 56, 96, 0.18);
+  --radius-large: 28px;
+  --radius-medium: 20px;
+  --radius-small: 12px;
+  font-family: 'Poppins', 'Segoe UI', sans-serif;
 }
 
 * {
@@ -20,260 +27,65 @@ html {
 
 body {
   margin: 0;
-  font-family: var(--font-sans);
-  background: radial-gradient(circle at top, rgba(34, 209, 238, 0.08), transparent 55%),
-    radial-gradient(circle at 20% 20%, rgba(19, 76, 111, 0.35), transparent 60%),
-    linear-gradient(160deg, #050c1a 0%, #0d1b2a 45%, #102b46 100%);
+  font-family: var(--font-sans, 'Poppins', 'Segoe UI', sans-serif);
+  background: linear-gradient(180deg, #fafdff 0%, #f1f5fb 45%, #e9f1f8 100%);
   color: var(--color-text);
   line-height: 1.6;
   min-height: 100vh;
-  position: relative;
-  overflow-x: hidden;
+  scroll-padding-top: 120px;
 }
 
-body::before {
-  content: '';
-  position: fixed;
-  inset: -40vh -20vw auto auto;
-  width: 60vw;
-  height: 60vw;
-  background: radial-gradient(circle, rgba(34, 209, 238, 0.15), transparent 60%);
-  filter: blur(20px);
-  opacity: 0.8;
-  pointer-events: none;
-  z-index: -1;
-  animation: float 18s ease-in-out infinite;
+img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+a {
+  color: inherit;
 }
 
 main {
   min-height: 100vh;
 }
 
+h1,
+h2,
+h3,
+h4 {
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 0;
+}
+
+p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
 .page {
   display: flex;
   flex-direction: column;
   gap: 6rem;
-  padding-bottom: 4rem;
+  padding: 6rem 0 4rem;
 }
 
 section {
-  padding: 0 1.5rem;
   position: relative;
-  scroll-margin-top: 96px;
 }
 
-.hero {
-  position: relative;
-  min-height: clamp(520px, 75vh, 680px);
-  display: grid;
-  align-items: center;
-  padding: 5rem 1.5rem;
-  background: radial-gradient(circle at top right, rgba(34, 209, 238, 0.18), transparent 58%),
-    linear-gradient(130deg, rgba(6, 10, 31, 0.95), rgba(18, 72, 107, 0.88));
-  overflow: hidden;
-}
-
-.hero__overlay {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(120deg, rgba(13, 27, 42, 0.9), rgba(13, 110, 140, 0.55));
-}
-
-.hero__light {
-  position: absolute;
-  border-radius: 999px;
-  filter: blur(60px);
-  opacity: 0.65;
-  background: radial-gradient(circle, rgba(34, 209, 238, 0.5), transparent 70%);
-  pointer-events: none;
-  animation: float 24s ease-in-out infinite;
-}
-
-.hero__light--one {
-  width: 420px;
-  height: 420px;
-  top: -120px;
-  right: -180px;
-}
-
-.hero__light--two {
-  width: 280px;
-  height: 280px;
-  bottom: -120px;
-  left: -80px;
-  animation-delay: 6s;
-}
-
-.hero__inner {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  gap: 3rem;
-  max-width: 1200px;
+.section__inner {
+  width: min(1120px, 100%);
   margin: 0 auto;
+  padding: 0 1.5rem;
 }
 
-.hero__content {
-  max-width: 720px;
-  display: grid;
-  gap: 1.5rem;
-}
-
-.hero__eyebrow {
+.section-eyebrow {
   text-transform: uppercase;
-  letter-spacing: 0.12em;
   font-size: 0.85rem;
-  color: var(--color-accent);
-  margin-bottom: 1rem;
-}
-
-.hero__title {
-  font-size: clamp(2.5rem, 5vw, 3.8rem);
-  line-height: 1.1;
-  margin-bottom: 1.5rem;
-  margin-top: 0;
-  text-wrap: balance;
-}
-
-.hero__subtitle {
-  max-width: 620px;
-  color: var(--color-muted);
-  margin-bottom: 2rem;
-}
-
-.hero__list {
-  display: grid;
-  gap: 0.75rem;
-  margin: 0 0 2.5rem;
-  padding: 0;
-  list-style: none;
-  color: var(--color-text);
-}
-
-.hero__list li {
-  display: flex;
-  gap: 0.65rem;
-  align-items: flex-start;
-  font-weight: 500;
-}
-
-.hero__list li::before {
-  content: '▹';
-  color: var(--color-accent);
-  font-size: 1rem;
-  transform: translateY(0.15rem);
-}
-
-.hero__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  margin-top: 0.5rem;
-}
-
-.hero__badge {
-  margin-top: 3rem;
-  display: inline-flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  padding: 1rem 1.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 999px;
-  backdrop-filter: blur(12px);
-  background: rgba(16, 44, 67, 0.65);
-}
-
-.hero__badge-title {
-  font-weight: 600;
-  letter-spacing: 0.08em;
-}
-
-.hero__badge-text {
-  font-size: 0.9rem;
-  color: var(--color-muted);
-}
-
-.hero__media {
-  display: grid;
-  gap: 1.5rem;
-}
-
-.hero__photo {
-  position: relative;
-  overflow: hidden;
-  border-radius: 24px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.4);
-}
-
-.hero__photo img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
-
-.hero__photo--primary {
-  min-height: 320px;
-}
-
-.hero__photo-stack {
-  display: grid;
-  gap: 1rem;
-}
-
-.hero__note {
-  display: grid;
-  gap: 0.5rem;
-  padding: 1.25rem 1.5rem;
-  border-radius: 18px;
-  background: rgba(8, 32, 50, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  color: var(--color-muted);
-  max-width: 360px;
-  backdrop-filter: blur(10px);
-}
-
-.hero__note span {
-  color: var(--color-accent);
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-size: 0.75rem;
-}
-
-.button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 999px;
-  padding: 0.85rem 1.9rem;
-  font-weight: 600;
-  text-decoration: none;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease;
-  border: 1px solid transparent;
-}
-
-.button--primary {
-  background: linear-gradient(135deg, var(--color-accent) 0%, var(--color-accent-strong) 100%);
-  color: #082032;
-  box-shadow: 0 10px 30px rgba(15, 176, 206, 0.35);
-}
-
-.button--primary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 18px 40px rgba(15, 176, 206, 0.4);
-}
-
-.button--ghost {
-  border-color: rgba(255, 255, 255, 0.35);
-  color: var(--color-text);
-  background: rgba(8, 32, 50, 0.4);
-}
-
-.button--ghost:hover {
-  transform: translateY(-2px);
-  border-color: rgba(255, 255, 255, 0.6);
+  letter-spacing: 0.16em;
+  color: var(--color-primary-strong);
+  margin-bottom: 0.75rem;
 }
 
 .section-heading {
@@ -284,80 +96,491 @@ section {
   gap: 0.75rem;
 }
 
-.section-eyebrow {
-  text-transform: uppercase;
-  font-size: 0.85rem;
-  letter-spacing: 0.16em;
-  color: var(--color-accent);
-  margin-bottom: 0.75rem;
-}
-
 .section-description {
   color: var(--color-muted);
-  margin-top: 1rem;
 }
 
-.selling-points {
-  position: relative;
-}
-
-.selling-points::after {
-  content: '';
+.sr-only {
   position: absolute;
-  inset: auto 10% -12% 10%;
+  width: 1px;
   height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(34, 209, 238, 0.3), transparent);
-  pointer-events: none;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
-.selling-points__grid,
-.services__grid,
-.process__grid {
-  display: grid;
+.site-topbar {
+  background: var(--color-primary-strong);
+  color: #f7fbff;
+  font-size: 0.85rem;
+}
+
+.site-topbar__inner {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  padding: 0.65rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.site-topbar__links {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.site-topbar__links a {
+  color: #f7fbff;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.site-topbar__links a:hover,
+.site-topbar__links a:focus-visible {
+  text-decoration: underline;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid rgba(15, 31, 51, 0.06);
+}
+
+.site-header__inner {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  padding: 0.9rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.site-header__brand {
+  font-weight: 700;
+  font-size: 1rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.site-header__nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
   gap: 1.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
-.card,
-.service-card,
-.process-card {
-  background: linear-gradient(160deg, rgba(16, 44, 67, 0.92), rgba(9, 28, 45, 0.92));
-  border-radius: 18px;
-  padding: 2rem;
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.28);
+.site-header__nav a {
+  color: var(--color-muted);
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.95rem;
+  transition: color 0.2s ease;
+}
+
+.site-header__nav a:hover,
+.site-header__nav a:focus-visible {
+  color: var(--color-primary);
+}
+
+.site-header__nav--desktop {
+  display: none;
+}
+
+.site-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.site-header__cta {
+  display: none;
+  padding: 0.65rem 1.3rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-soft));
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  box-shadow: 0 12px 30px rgba(13, 140, 208, 0.2);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.card p,
-.service-card p,
-.process-card p {
+.site-header__cta:hover,
+.site-header__cta:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(13, 140, 208, 0.25);
+}
+
+.site-header__menu-button {
+  background: transparent;
+  border: none;
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-end;
+  gap: 0.3rem;
+  padding: 0.35rem 0;
+  cursor: pointer;
+}
+
+.site-header__menu-button span {
+  display: block;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--color-text);
+  transition: width 0.2s ease;
+}
+
+.site-header__menu-button span:nth-child(1) {
+  width: 26px;
+}
+
+.site-header__menu-button span:nth-child(2) {
+  width: 20px;
+}
+
+.site-header__menu-button span:nth-child(3) {
+  width: 30px;
+}
+
+.site-header__menu-button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 4px;
+}
+
+.site-header__nav--mobile {
+  margin-top: 0.75rem;
+  width: min(1120px, 100%);
+  margin-left: auto;
+  margin-right: auto;
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: var(--radius-medium);
+  border: 1px solid rgba(15, 31, 51, 0.08);
+  box-shadow: var(--shadow-soft);
+  padding: 1.5rem;
+}
+
+.site-header__nav--mobile ul {
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.site-header__mobile-extra {
+  margin-top: 1.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(15, 31, 51, 0.08);
+  display: grid;
+  gap: 0.65rem;
+}
+
+.site-header__mobile-extra a {
+  text-decoration: none;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.hero {
+  overflow: hidden;
+  padding: 5.5rem 0 5rem;
+}
+
+.hero__background {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(20, 180, 230, 0.35), transparent 60%),
+    linear-gradient(120deg, #e3f5ff 0%, #ffffff 60%);
+  z-index: -2;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: auto -40% -40% -40%;
+  height: 420px;
+  background: radial-gradient(circle, rgba(14, 140, 208, 0.08), transparent 65%);
+  z-index: -1;
+}
+
+.hero__inner {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: grid;
+  gap: 3rem;
+}
+
+.hero__content {
+  display: grid;
+  gap: 1.4rem;
+  max-width: 560px;
+}
+
+.hero__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.82rem;
+  color: var(--color-primary-strong);
+}
+
+.hero__title {
+  font-size: clamp(2.5rem, 5vw, 3.8rem);
+  line-height: 1.1;
+  color: var(--color-text);
+}
+
+.hero__subtitle {
+  font-size: 1.05rem;
   color: var(--color-muted);
 }
 
-.service-card {
+.hero__list {
+  list-style: none;
   padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.hero__list li {
+  display: flex;
+  gap: 0.6rem;
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.hero__list li::before {
+  content: '✓';
+  color: var(--color-primary);
+  font-weight: 700;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.9rem 1.9rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+  border: 1px solid transparent;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-soft));
+  color: #fff;
+  box-shadow: 0 12px 40px rgba(13, 140, 208, 0.25);
+}
+
+.button--primary:hover,
+.button--primary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 50px rgba(13, 140, 208, 0.32);
+}
+
+.button--ghost {
+  border-color: rgba(13, 140, 208, 0.25);
+  background: rgba(255, 255, 255, 0.65);
+  color: var(--color-primary-strong);
+}
+
+.button--ghost:hover,
+.button--ghost:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(13, 140, 208, 0.45);
+}
+
+.hero__support {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: var(--radius-medium);
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(15, 31, 51, 0.08);
+  box-shadow: var(--shadow-soft);
+}
+
+.hero__support-item {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.hero__support-item strong {
+  font-size: 1.2rem;
+  color: var(--color-text);
+}
+
+.hero__support-item span {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.hero__media {
+  display: grid;
+  gap: 1.25rem;
+  justify-items: start;
+}
+
+.hero__image {
+  position: relative;
+  border-radius: var(--radius-large);
   overflow: hidden;
+  box-shadow: var(--shadow-strong);
+}
+
+.hero__image img {
+  width: 100%;
+  height: clamp(260px, 40vw, 420px);
+  object-fit: cover;
+}
+
+.hero__media-badge {
+  position: absolute;
+  bottom: 1.5rem;
+  left: 1.5rem;
+  padding: 1rem 1.2rem;
+  background: rgba(15, 31, 51, 0.8);
+  color: #f7fbff;
+  border-radius: var(--radius-small);
+  display: grid;
+  gap: 0.25rem;
+  max-width: 220px;
+}
+
+.hero__media-badge strong {
+  font-size: 1.1rem;
+}
+
+.hero__contact-card {
+  padding: 1.8rem;
+  border-radius: var(--radius-medium);
+  background: var(--color-surface);
+  border: 1px solid rgba(15, 31, 51, 0.08);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.hero__contact-eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  color: var(--color-primary-strong);
+}
+
+.hero__contact-phone {
+  font-size: 1.9rem;
+  font-weight: 700;
+  color: var(--color-primary-strong);
+  text-decoration: none;
+}
+
+.hero__contact-phone:hover,
+.hero__contact-phone:focus-visible {
+  text-decoration: underline;
+}
+
+.hero__contact-card p {
+  color: var(--color-muted);
+}
+
+.hero__contact-link {
+  color: var(--color-primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.hero__contact-link:hover,
+.hero__contact-link:focus-visible {
+  text-decoration: underline;
+}
+
+.selling-points {
+  background: var(--color-surface);
+  padding: 4.5rem 0;
+}
+
+.selling-points__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+  background: var(--color-surface);
+  border-radius: var(--radius-medium);
+  border: 1px solid rgba(15, 31, 51, 0.08);
+  padding: 2rem;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.65rem;
+}
+
+.card h3 {
+  font-size: 1.1rem;
+}
+
+.services {
+  background: var(--color-surface-soft);
+  padding: 4.5rem 0;
+}
+
+.services__grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.service-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-medium);
+  overflow: hidden;
+  border: 1px solid rgba(15, 31, 51, 0.08);
+  box-shadow: var(--shadow-soft);
+  display: grid;
 }
 
 .service-card__media {
   position: relative;
   aspect-ratio: 4 / 3;
   overflow: hidden;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .service-card__media img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  display: block;
 }
 
 .service-card__content {
+  padding: 1.75rem;
   display: grid;
   gap: 0.75rem;
-  padding: 2rem;
+}
+
+.highlights {
+  background: var(--color-surface);
+  padding: 4.5rem 0;
 }
 
 .highlights__grid {
@@ -367,120 +590,202 @@ section {
 }
 
 .highlight-card {
-  background: linear-gradient(160deg, rgba(16, 44, 67, 0.9), rgba(6, 19, 32, 0.9));
-  border-radius: 20px;
+  background: var(--color-surface);
+  border-radius: var(--radius-medium);
+  border: 1px solid rgba(15, 31, 51, 0.08);
   padding: 2.25rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.28);
+  box-shadow: var(--shadow-soft);
   display: grid;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
-.highlight-card h3 {
-  margin: 0;
-}
-
-.highlight-card p {
-  color: var(--color-muted);
-  margin: 0;
+.gallery {
+  background: var(--color-surface-soft);
+  padding: 4.5rem 0;
 }
 
 .gallery__grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.project-card {
+  display: grid;
+  gap: 1.5rem;
+  background: var(--color-surface);
+  border-radius: var(--radius-medium);
+  padding: 1.75rem;
+  border: 1px solid rgba(15, 31, 51, 0.08);
+  box-shadow: var(--shadow-soft);
+}
+
+.project-card__header {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.project-card__header span {
+  color: var(--color-muted);
+}
+
+.project-card__carousel {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.project-card__viewport {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  padding-bottom: 0.25rem;
+}
+
+.project-card__viewport::-webkit-scrollbar {
+  height: 6px;
+}
+
+.project-card__viewport::-webkit-scrollbar-thumb {
+  background: rgba(15, 31, 51, 0.2);
+  border-radius: 999px;
+}
+
+.project-card__slide {
+  min-width: 80%;
+  border-radius: var(--radius-small);
+  overflow: hidden;
+  border: 1px solid rgba(15, 31, 51, 0.1);
+  scroll-snap-align: start;
+  background: #f5f9fd;
+  box-shadow: 0 12px 30px rgba(15, 64, 109, 0.16);
+}
+
+.project-card__slide img {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+}
+
+.project-card__controls {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.project-card__control {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(13, 140, 208, 0.12);
+  color: var(--color-primary-strong);
+  font-size: 1.4rem;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.project-card__control:hover,
+.project-card__control:focus-visible {
+  background: rgba(13, 140, 208, 0.25);
+}
+
+.cta {
+  padding: 4.5rem 0;
+  background: linear-gradient(135deg, rgba(13, 140, 208, 0.1), rgba(14, 140, 208, 0));
+}
+
+.cta__inner {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: grid;
+  gap: 2.5rem;
+}
+
+.cta__text {
+  display: grid;
+  gap: 1rem;
+  max-width: 520px;
+}
+
+.cta__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1.2rem;
+}
+
+.cta__list li {
+  background: var(--color-surface);
+  border-radius: var(--radius-medium);
+  border: 1px solid rgba(15, 31, 51, 0.08);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.process {
+  background: var(--color-surface);
+  padding: 4.5rem 0;
+}
+
+.process__grid {
   display: grid;
   gap: 1.5rem;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
-.gallery__item {
+.process-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-medium);
+  border: 1px solid rgba(15, 31, 51, 0.08);
+  padding: 1.8rem;
+  box-shadow: var(--shadow-soft);
   display: grid;
-  border-radius: 20px;
-  overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(16, 44, 67, 0.7);
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3);
-  transition: transform 0.4s ease, box-shadow 0.4s ease;
-}
-
-.gallery__item img {
-  width: 100%;
-  height: 220px;
-  object-fit: cover;
-  display: block;
-}
-
-.gallery__item figcaption {
-  display: grid;
-  gap: 0.35rem;
-  padding: 1.25rem 1.5rem 1.75rem;
-}
-
-.gallery__item span {
-  color: var(--color-muted);
-}
-
-.cta {
-  display: grid;
-  gap: 2rem;
-  align-items: center;
-  padding: 4rem 1.5rem;
-  background: radial-gradient(circle at top left, rgba(34, 209, 238, 0.2), transparent 55%),
-    linear-gradient(120deg, rgba(16, 44, 67, 0.65), rgba(13, 27, 42, 0.92));
-  border-radius: 24px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 25px 70px rgba(0, 0, 0, 0.3);
-}
-
-.cta__list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 1.5rem;
-}
-
-.cta__list li {
-  background: rgba(16, 44, 67, 0.55);
-  border-radius: 14px;
-  padding: 1.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.cta__list span {
-  display: block;
-  color: var(--color-muted);
-  margin-top: 0.5rem;
-}
-
-.cta__list li:hover {
-  transform: translateY(-6px);
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3);
-}
-
-.contact {
-  padding-bottom: 6rem;
-}
-
-.contact__form {
-  max-width: 640px;
-  margin: 0 auto;
-  display: grid;
-  gap: 1.5rem;
-  background: linear-gradient(160deg, rgba(16, 44, 67, 0.95), rgba(9, 28, 45, 0.92));
-  border-radius: 24px;
-  padding: 2.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 25px 70px rgba(0, 0, 0, 0.3);
-}
-
-.form-row {
-  display: flex;
-  flex-direction: column;
   gap: 0.6rem;
 }
 
-label {
+.contact {
+  background: var(--color-surface-soft);
+  padding: 4.5rem 0 5.5rem;
+}
+
+.contact__inner {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: grid;
+  gap: 2.5rem;
+}
+
+.contact__intro {
+  max-width: 620px;
+}
+
+.contact__form {
+  background: var(--color-surface);
+  border-radius: var(--radius-medium);
+  border: 1px solid rgba(15, 31, 51, 0.1);
+  box-shadow: var(--shadow-soft);
+  padding: 2.5rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.form-row {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.form-row label {
   font-weight: 600;
+  color: var(--color-text);
 }
 
 input,
@@ -488,9 +793,9 @@ select,
 textarea {
   font: inherit;
   padding: 0.85rem 1rem;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(8, 32, 50, 0.65);
+  border-radius: var(--radius-small);
+  border: 1px solid rgba(15, 31, 51, 0.15);
+  background: #fafdff;
   color: var(--color-text);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
@@ -499,109 +804,171 @@ input:focus,
 select:focus,
 textarea:focus {
   outline: none;
-  border-color: var(--color-accent);
-  box-shadow: 0 0 0 3px rgba(34, 209, 238, 0.3);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(13, 140, 208, 0.15);
+}
+
+textarea {
+  resize: vertical;
+}
+
+.contact__info {
+  background: var(--color-surface);
+  border-radius: var(--radius-medium);
+  border: 1px solid rgba(15, 31, 51, 0.1);
+  box-shadow: var(--shadow-soft);
+  padding: 2.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.contact__info a {
+  color: var(--color-primary-strong);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.contact__info a:hover,
+.contact__info a:focus-visible {
+  text-decoration: underline;
+}
+
+.contact__info ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
 }
 
 .footer {
-  padding: 3rem 1.5rem 4rem;
+  background: #0f1f33;
+  color: #f7fbff;
+  padding: 3rem 0 3.5rem;
+}
+
+.footer__inner {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  padding: 0 1.5rem;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  gap: 1rem;
-  background: rgba(10, 22, 34, 0.88);
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  gap: 1.5rem;
+}
+
+.footer__brand {
+  display: grid;
+  gap: 0.5rem;
 }
 
 .footer__contact {
   display: flex;
-  gap: 1.5rem;
   flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
 }
 
 .footer__contact a {
-  color: var(--color-accent);
+  color: var(--color-primary-soft);
   text-decoration: none;
 }
 
-.footer__contact a:hover {
+.footer__contact a:hover,
+.footer__contact a:focus-visible {
   text-decoration: underline;
 }
 
-@keyframes float {
-  0%,
-  100% {
-    transform: translate3d(0, 0, 0);
+@media (min-width: 768px) {
+  .site-header__nav--desktop {
+    display: block;
   }
-  50% {
-    transform: translate3d(0, -14px, 0);
+
+  .site-header__cta {
+    display: inline-flex;
+  }
+
+  .site-header__menu-button {
+    display: none;
+  }
+
+  .hero__inner {
+    grid-template-columns: 1.05fr 0.95fr;
+    align-items: center;
+  }
+
+  .cta__inner {
+    grid-template-columns: 1.1fr 0.9fr;
+    align-items: center;
+  }
+
+  .contact__inner {
+    grid-template-columns: 1fr 1.05fr;
+    align-items: start;
+  }
+
+  .contact__form {
+    grid-column: 2 / 3;
+  }
+
+  .contact__info {
+    grid-column: 1 / 2;
+    position: sticky;
+    top: 140px;
   }
 }
 
 @media (min-width: 992px) {
-  section {
-    padding: 0 6rem;
-  }
-
   .hero {
-    padding: 6rem 6rem;
+    padding: 6.5rem 0 6rem;
   }
 
-  .cta {
-    grid-template-columns: 1.1fr 0.9fr;
-    padding: 5rem 6rem;
-  }
-}
-
-@media (min-width: 768px) {
-  .hero__inner {
-    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
-    align-items: center;
+  .cta__inner {
+    gap: 3rem;
   }
 
-  .hero__media {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 0.85fr);
-    align-items: stretch;
-  }
-
-  .hero__photo--primary {
-    min-height: 100%;
+  .project-card__slide {
+    min-width: 55%;
   }
 }
 
 @media (max-width: 640px) {
+  .page {
+    padding: 4.5rem 0 3rem;
+    gap: 4.5rem;
+  }
+
+  .site-topbar__inner {
+    justify-content: center;
+  }
+
   .hero {
-    padding: 4rem 1.25rem 3.5rem;
-    min-height: auto;
+    padding: 4.5rem 0 3.5rem;
   }
 
   .hero__inner {
-    gap: 2.5rem;
+    padding: 0 1.25rem;
   }
 
-  .hero__media {
-    gap: 1rem;
+  .hero__image img {
+    height: 260px;
   }
 
-  .hero__photo {
-    border-radius: 18px;
-  }
-
-  .hero__note {
-    max-width: none;
-  }
-
-  .hero__list {
-    margin-bottom: 2rem;
-  }
-
-  .hero__badge {
+  .hero__contact-card {
     width: 100%;
-    align-items: center;
-    border-radius: 24px;
   }
 
-  .contact__form {
+  .cta__inner,
+  .contact__inner {
+    padding: 0 1.25rem;
+  }
+
+  .contact__form,
+  .contact__info {
     padding: 2rem;
+  }
+
+  .project-card__slide {
+    min-width: 85%;
   }
 }

--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,7 @@
 'use client';
 
-import { motion } from 'framer-motion';
+import { useEffect, useRef, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
 
 const services = [
   {
@@ -45,33 +46,100 @@ const projects = [
   {
     name: 'Residencial Valdeiglesias',
     detail: 'Piscina climatizada con cloración salina y domótica integrada.',
-    image: 'https://images.unsplash.com/photo-1540541338287-41700207dee6?auto=format&fit=crop&w=1000&q=80'
+    images: [
+      {
+        src: 'https://images.unsplash.com/photo-1540541338287-41700207dee6?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Piscina climatizada con cubierta integrada'
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1563911302283-d2bc129e7570?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Detalle de iluminación nocturna en piscina climatizada'
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Zona wellness contigua a piscina climatizada'
+      }
+    ]
   },
   {
     name: 'Hotel Sierra Azul',
     detail: 'Lámina de agua infinita con iluminación RGB programable.',
-    image: 'https://images.unsplash.com/photo-1506126613408-eca07ce68773?auto=format&fit=crop&w=1000&q=80'
+    images: [
+      {
+        src: 'https://images.unsplash.com/photo-1506126613408-eca07ce68773?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Piscina infinita de hotel con vistas a la montaña'
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1505761671935-60b3a7427bad?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Piscina infinita al atardecer con luces encendidas'
+      }
+    ]
   },
   {
     name: 'Urbanización Montealto',
     detail: 'Reforma integral y automatización de control químico.',
-    image: 'https://images.unsplash.com/photo-1507502707541-f369a3b18502?auto=format&fit=crop&w=1000&q=80'
+    images: [
+      {
+        src: 'https://images.unsplash.com/photo-1507502707541-f369a3b18502?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Piscina reformada en urbanización con borde ancho'
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1500929426704-2211a46a1c38?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Detalle de jacuzzi integrado junto a piscina comunitaria'
+      }
+    ]
   },
   {
     name: 'Vivienda unifamiliar Los Arroyos',
     detail: 'Microcemento, playa húmeda y jacuzzi integrado.',
-    image: 'https://images.unsplash.com/photo-1516156008625-3a9d6067fab5?auto=format&fit=crop&w=1000&q=80'
+    images: [
+      {
+        src: 'https://images.unsplash.com/photo-1516156008625-3a9d6067fab5?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Piscina privada con revestimiento en microcemento'
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1504149212288-9571d7108010?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Zona de relax con jacuzzi integrado en piscina'
+      }
+    ]
   },
   {
     name: 'Comunidad Jardines del Tajo',
     detail: 'Plan de mantenimiento integral con reportes digitales.',
-    image: 'https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1000&q=80'
+    images: [
+      {
+        src: 'https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Piscina comunitaria rodeada de vegetación'
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Zona infantil en piscina comunitaria'
+      }
+    ]
   },
   {
     name: 'Club Náutico San Martín',
     detail: 'Renovación del vaso y sistemas de filtración de alto rendimiento.',
-    image: 'https://images.unsplash.com/photo-1611892440504-42a792e24d32?auto=format&fit=crop&w=1000&q=80'
+    images: [
+      {
+        src: 'https://images.unsplash.com/photo-1611892440504-42a792e24d32?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Piscina exterior junto a club náutico'
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1517832207067-4db24a2ae47c?auto=format&fit=crop&w=1200&q=80',
+        alt: 'Zona de nado deportivo en piscina del club'
+      }
+    ]
   }
+];
+
+const navLinks = [
+  { href: '#inicio', label: 'Inicio' },
+  { href: '#servicios', label: 'Servicios' },
+  { href: '#ventajas', label: 'Ventajas' },
+  { href: '#proyectos', label: 'Proyectos' },
+  { href: '#proceso', label: 'Proceso' },
+  { href: '#presupuesto', label: 'Contacto' }
 ];
 
 const sellingPoints = [
@@ -87,6 +155,12 @@ const sellingPoints = [
     label: 'Garantía Piscina Moisés',
     detail: 'Materiales homologados, personal propio y servicio posventa con seguimiento continuo.'
   }
+];
+
+const heroSupportItems = [
+  { title: '15 años', description: 'Experiencia local en obra nueva y reformas' },
+  { title: '+250 proyectos', description: 'Piscinas entregadas con garantías reales' },
+  { title: 'Respuesta 24h', description: 'Atención directa ante cualquier incidencia' }
 ];
 
 const steps = [
@@ -168,11 +242,6 @@ const fadeListItem = {
   }
 };
 
-const mediaReveal = {
-  hidden: { opacity: 0, scale: 0.92 },
-  visible: { opacity: 1, scale: 1, transition: { duration: 0.8, ease: 'easeOut' } }
-};
-
 const cardReveal = {
   hidden: { opacity: 0, y: 26 },
   visible: (index = 0) => ({
@@ -191,309 +260,475 @@ const contactReveal = {
   }
 };
 
+const heroMedia = {
+  hidden: { opacity: 0, scale: 0.96 },
+  visible: {
+    opacity: 1,
+    scale: 1,
+    transition: { duration: 0.7, ease: 'easeOut', delay: 0.1 }
+  }
+};
+
 const inViewConfig = {
   initial: 'hidden',
   whileInView: 'visible',
   viewport: { once: true, amount: 0.2 }
 };
 
-export default function HomePage() {
+const mobileMenu = {
+  hidden: { opacity: 0, y: -16 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+  exit: { opacity: 0, y: -12, transition: { duration: 0.2, ease: 'easeIn' } }
+};
+
+function ProjectCarousel({ project, index }) {
+  const scrollRef = useRef(null);
+
+  const handleScroll = (direction) => {
+    if (!scrollRef.current) return;
+    const distance = scrollRef.current.clientWidth * 0.9;
+    scrollRef.current.scrollBy({ left: direction * distance, behavior: 'smooth' });
+  };
+
+  const hasMultipleImages = project.images.length > 1;
+
   return (
-    <main className="page">
-      <motion.section className="hero" initial="hidden" animate="visible" variants={sectionFade}>
-        <div className="hero__overlay" />
-        <div className="hero__light hero__light--one" aria-hidden />
-        <div className="hero__light hero__light--two" aria-hidden />
-        <motion.div className="hero__inner" variants={heroContainer}>
-          <motion.div className="hero__content" variants={heroContent}>
-            <motion.p className="hero__eyebrow" variants={fadeUp}>
-              𝓟𝓲𝓼𝓬𝓲𝓷𝓪 𝓜𝓸𝓲𝓼𝓮𝓼 · Especialistas en piscinas premium
-            </motion.p>
-            <motion.h1 className="hero__title" variants={fadeUp}>
-              Diseñamos, proyectamos y cuidamos piscinas sin límites
-            </motion.h1>
-            <motion.p className="hero__subtitle" variants={fadeUp}>
-              Convertimos cada espacio acuático en una experiencia segura y elegante: desde nuevas piscinas proyectadas hasta la
-              renovación total con tecnología de cloración salina.
-            </motion.p>
-            <motion.ul className="hero__list" variants={listVariants}>
+    <motion.article
+      className="project-card"
+      variants={cardReveal}
+      custom={index}
+      whileHover={{ y: -6, boxShadow: '0 28px 70px rgba(15, 64, 109, 0.18)' }}
+    >
+      <div className="project-card__header">
+        <strong>{project.name}</strong>
+        <span>{project.detail}</span>
+      </div>
+      <div className="project-card__carousel">
+        <div className="project-card__viewport" ref={scrollRef}>
+          {project.images.map((image) => (
+            <div className="project-card__slide" key={image.src}>
+              <img src={image.src} alt={image.alt} loading="lazy" />
+            </div>
+          ))}
+        </div>
+        {hasMultipleImages && (
+          <div className="project-card__controls">
+            <button
+              type="button"
+              className="project-card__control"
+              onClick={() => handleScroll(-1)}
+              aria-label={`Ver imagen anterior de ${project.name}`}
+            >
+              ‹
+            </button>
+            <button
+              type="button"
+              className="project-card__control"
+              onClick={() => handleScroll(1)}
+              aria-label={`Ver imagen siguiente de ${project.name}`}
+            >
+              ›
+            </button>
+          </div>
+        )}
+      </div>
+    </motion.article>
+  );
+}
+
+export default function HomePage() {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    document.body.style.overflow = menuOpen ? 'hidden' : '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [menuOpen]);
+
+  const closeMenu = () => setMenuOpen(false);
+
+  return (
+    <>
+      <motion.header className="site-header" initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }}>
+        <div className="site-topbar">
+          <div className="site-topbar__inner">
+            <span>Construcción y mantenimiento de piscinas en Madrid</span>
+            <div className="site-topbar__links">
+              <a href="tel:+34911011222">91 101 12 22</a>
+              <a href="mailto:hola@piscinamoises.es">hola@piscinamoises.es</a>
+            </div>
+          </div>
+        </div>
+        <div className="site-header__inner">
+          <a className="site-header__brand" href="#inicio">
+            Piscina Moisés
+          </a>
+          <nav className="site-header__nav site-header__nav--desktop">
+            <ul>
+              {navLinks.map((link) => (
+                <li key={link.href}>
+                  <a href={link.href}>{link.label}</a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+          <div className="site-header__actions">
+            <a className="site-header__cta" href="#presupuesto">
+              Pedir presupuesto
+            </a>
+            <button
+              className="site-header__menu-button"
+              type="button"
+              onClick={() => setMenuOpen((prev) => !prev)}
+              aria-expanded={menuOpen}
+              aria-controls="mobile-menu"
+            >
+              <span />
+              <span />
+              <span />
+              <span className="sr-only">Abrir o cerrar menú</span>
+            </button>
+          </div>
+        </div>
+        <AnimatePresence>
+          {menuOpen && (
+            <motion.nav
+              id="mobile-menu"
+              className="site-header__nav site-header__nav--mobile"
+              variants={mobileMenu}
+              initial="hidden"
+              animate="visible"
+              exit="exit"
+            >
+              <ul>
+                {navLinks.map((link) => (
+                  <li key={link.href}>
+                    <a href={link.href} onClick={closeMenu}>
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+              <div className="site-header__mobile-extra">
+                <a href="tel:+34911011222" onClick={closeMenu}>
+                  Llamar al 91 101 12 22
+                </a>
+                <a href="#presupuesto" onClick={closeMenu}>
+                  Solicitar presupuesto
+                </a>
+              </div>
+            </motion.nav>
+          )}
+        </AnimatePresence>
+      </motion.header>
+      <main className="page">
+        <motion.section className="hero" id="inicio" initial="hidden" animate="visible" variants={sectionFade}>
+          <div className="hero__background" aria-hidden />
+          <motion.div className="hero__inner" variants={heroContainer}>
+            <motion.div className="hero__content" variants={heroContent}>
+              <motion.p className="hero__eyebrow" variants={fadeUp}>
+                Construcción de piscinas en Madrid y zonas limítrofes
+              </motion.p>
+              <motion.h1 className="hero__title" variants={fadeUp}>
+                Tu piscina a medida lista para disfrutar todo el año
+              </motion.h1>
+              <motion.p className="hero__subtitle" variants={fadeUp}>
+                Diseñamos, ejecutamos y mantenemos piscinas residenciales y comunitarias con personal propio, materiales
+                certificados y supervisión constante para garantizar un agua impecable.
+              </motion.p>
+              <motion.ul className="hero__list" variants={listVariants}>
+                {[
+                  'Obra nueva en hormigón gunitado con plazos cerrados y garantía de 10 años.',
+                  'Reformas completas, cambio de coronaciones e impermeabilizaciones sin fugas.',
+                  'Planes de mantenimiento con informes digitales y respuesta técnica en 24h.'
+                ].map((item) => (
+                  <motion.li key={item} variants={fadeListItem}>
+                    {item}
+                  </motion.li>
+                ))}
+              </motion.ul>
+              <motion.div className="hero__actions" variants={fadeUp}>
+                <motion.a
+                  className="button button--primary"
+                  href="#presupuesto"
+                  whileHover={{ y: -4, boxShadow: '0 16px 40px rgba(13, 140, 208, 0.4)' }}
+                  whileTap={{ scale: 0.97 }}
+                >
+                  Solicitar presupuesto
+                </motion.a>
+                <motion.a
+                  className="button button--ghost"
+                  href="#servicios"
+                  whileHover={{ y: -4, borderColor: 'rgba(13, 140, 208, 0.45)' }}
+                  whileTap={{ scale: 0.97 }}
+                >
+                  Ver servicios
+                </motion.a>
+              </motion.div>
+              <motion.div className="hero__support" variants={fadeUp}>
+                {heroSupportItems.map((item) => (
+                  <div key={item.title} className="hero__support-item">
+                    <strong>{item.title}</strong>
+                    <span>{item.description}</span>
+                  </div>
+                ))}
+              </motion.div>
+            </motion.div>
+            <motion.div className="hero__media" variants={heroMedia}>
+              <div className="hero__image">
+                <img
+                  src="https://images.unsplash.com/photo-1505761671935-60b3a7427bad?auto=format&fit=crop&w=1200&q=80"
+                  alt="Piscina moderna con borde infinito y zona de descanso"
+                />
+                <div className="hero__media-badge">
+                  <strong>+250 proyectos</strong>
+                  <span>Construidos y reformados con garantía integral</span>
+                </div>
+              </div>
+              <div className="hero__contact-card">
+                <span className="hero__contact-eyebrow">Asesoramiento inmediato</span>
+                <a className="hero__contact-phone" href="tel:+34911011222">
+                  91 101 12 22
+                </a>
+                <p>Atendemos Madrid, Toledo, Ávila y Segovia todos los días de la semana.</p>
+                <a className="hero__contact-link" href="mailto:hola@piscinamoises.es">
+                  hola@piscinamoises.es
+                </a>
+              </div>
+            </motion.div>
+          </motion.div>
+        </motion.section>
+
+        <motion.section className="selling-points" id="servicios" {...inViewConfig} variants={sectionFade}>
+          <div className="section__inner">
+            <motion.div className="section-heading" variants={fadeUp}>
+              <p className="section-eyebrow">Por qué nos eligen</p>
+              <h2>Soluciones integrales y artesanía en cada detalle</h2>
+              <p className="section-description">
+                Coordinamos todas las fases del proyecto con un interlocutor único. Desde el estudio inicial hasta el primer baño,
+                controlamos plazos, calidad y presupuesto para que disfrutes sin sorpresas.
+              </p>
+            </motion.div>
+            <div className="selling-points__grid">
+              {sellingPoints.map((point, index) => (
+                <motion.article
+                  className="card"
+                  key={point.label}
+                  variants={cardReveal}
+                  custom={index}
+                  whileHover={{ y: -8, boxShadow: '0 26px 70px rgba(15, 64, 109, 0.18)' }}
+                >
+                  <h3>{point.label}</h3>
+                  <p>{point.detail}</p>
+                </motion.article>
+              ))}
+            </div>
+          </div>
+        </motion.section>
+
+        <motion.section className="services" {...inViewConfig} variants={sectionFade}>
+          <div className="section__inner">
+            <motion.div className="section-heading" variants={fadeUp}>
+              <p className="section-eyebrow">Soluciones a medida</p>
+              <h2>Servicios especializados para cada necesidad</h2>
+            </motion.div>
+            <div className="services__grid">
+              {services.map((service, index) => (
+                <motion.article
+                  className="service-card"
+                  key={service.title}
+                  variants={cardReveal}
+                  custom={index}
+                  whileHover={{ y: -10, scale: 1.01 }}
+                >
+                  <div className="service-card__media">
+                    <motion.img src={service.image.src} alt={service.image.alt} loading="lazy" />
+                  </div>
+                  <div className="service-card__content">
+                    <h3>{service.title}</h3>
+                    <p>{service.description}</p>
+                  </div>
+                </motion.article>
+              ))}
+            </div>
+          </div>
+        </motion.section>
+
+        <motion.section className="highlights" id="ventajas" {...inViewConfig} variants={sectionFade}>
+          <div className="section__inner">
+            <motion.div className="section-heading" variants={fadeUp}>
+              <p className="section-eyebrow">Nuestra forma de trabajar</p>
+              <h2>Expertos en proyectos complejos y mantenimiento continuo</h2>
+              <p className="section-description">
+                Integramos arquitectura, ingeniería y mantenimiento en un mismo equipo. Cada piscina recibe un plan único con
+                inspecciones programadas, informes digitales y recomendaciones para optimizar recursos.
+              </p>
+            </motion.div>
+            <div className="highlights__grid">
+              {highlights.map((highlight, index) => (
+                <motion.article className="highlight-card" key={highlight.title} variants={cardReveal} custom={index}>
+                  <h3>{highlight.title}</h3>
+                  <p>{highlight.description}</p>
+                </motion.article>
+              ))}
+            </div>
+          </div>
+        </motion.section>
+
+        <motion.section className="gallery" id="proyectos" {...inViewConfig} variants={sectionFade}>
+          <div className="section__inner">
+            <motion.div className="section-heading" variants={fadeUp}>
+              <p className="section-eyebrow">Casos recientes</p>
+              <h2>Inspiración visual de nuestros proyectos</h2>
+              <p className="section-description">
+                Así combinamos estética, ingeniería y mantenimiento profesional en residencias privadas, hoteles y comunidades de
+                vecinos en la zona centro.
+              </p>
+            </motion.div>
+            <div className="gallery__grid">
+              {projects.map((project, index) => (
+                <ProjectCarousel key={project.name} project={project} index={index} />
+              ))}
+            </div>
+          </div>
+        </motion.section>
+
+        <motion.section className="cta" {...inViewConfig} variants={sectionFade}>
+          <div className="cta__inner">
+            <motion.div className="cta__text" variants={fadeUp}>
+              <p className="section-eyebrow">Piscinas impecables todo el año</p>
+              <h2>
+                Mantenimiento continuo
+                <br /> con seguimiento digital
+              </h2>
+              <p>
+                Recibe informes tras cada visita, controla el estado del agua y confía en un plan diseñado para tu piscina. Nos
+                encargamos de todo para que tú solo tengas que disfrutarla.
+              </p>
+            </motion.div>
+            <motion.ul className="cta__list" variants={fadeUp}>
               {[
-                'Mantenimiento profesional de piscinas residenciales y comunitarias.',
-                'Proyección completa de vasos en hormigón gunitado y acabados a medida.',
-                'Reformas estructurales, impermeabilización avanzada y domótica.',
-                'Fontanería especializada con equipos de sal y automatización inteligente.'
-              ].map((item) => (
-                <motion.li key={item} variants={fadeListItem}>
-                  {item}
+                {
+                  title: 'Visitas programadas',
+                  detail: 'Calendario adaptado a tu uso, con recordatorios automáticos.'
+                },
+                {
+                  title: 'Control químico preciso',
+                  detail: 'Mediciones periódicas y ajustes exactos para garantizar seguridad.'
+                },
+                {
+                  title: 'Asistencia 24/7',
+                  detail: 'Disponibilidad para emergencias con técnicos especializados.'
+                }
+              ].map((item, index) => (
+                <motion.li key={item.title} variants={cardReveal} custom={index}>
+                  <strong>{item.title}</strong>
+                  <span>{item.detail}</span>
                 </motion.li>
               ))}
             </motion.ul>
-            <motion.div className="hero__actions" variants={fadeUp}>
-              <motion.a
+          </div>
+        </motion.section>
+
+        <motion.section className="process" id="proceso" {...inViewConfig} variants={sectionFade}>
+          <div className="section__inner">
+            <motion.div className="section-heading" variants={fadeUp}>
+              <p className="section-eyebrow">Así trabajamos</p>
+              <h2>Un proceso claro, eficiente y sin sorpresas</h2>
+            </motion.div>
+            <div className="process__grid">
+              {steps.map((step, index) => (
+                <motion.article className="process-card" key={step.title} variants={cardReveal} custom={index}>
+                  <h3>{step.title}</h3>
+                  <p>{step.description}</p>
+                </motion.article>
+              ))}
+            </div>
+          </div>
+        </motion.section>
+
+        <motion.section className="contact" id="presupuesto" {...inViewConfig} variants={sectionFade}>
+          <div className="contact__inner">
+            <motion.div className="contact__intro" variants={fadeUp}>
+              <p className="section-eyebrow">Solicita tu propuesta</p>
+              <h2>Pide un presupuesto personalizado</h2>
+              <p className="section-description">
+                Cuéntanos qué necesita tu piscina y te devolveremos una propuesta en menos de 24 horas.
+              </p>
+            </motion.div>
+            <motion.form className="contact__form" variants={contactReveal}>
+              <motion.div className="form-row" variants={fadeUp}>
+                <label htmlFor="nombre">Nombre y apellidos</label>
+                <input id="nombre" name="nombre" type="text" placeholder="Tu nombre" required />
+              </motion.div>
+              <motion.div className="form-row" variants={fadeUp}>
+                <label htmlFor="email">Correo electrónico</label>
+                <input id="email" name="email" type="email" placeholder="tucorreo@email.com" required />
+              </motion.div>
+              <motion.div className="form-row" variants={fadeUp}>
+                <label htmlFor="telefono">Teléfono</label>
+                <input id="telefono" name="telefono" type="tel" placeholder="Tu teléfono" />
+              </motion.div>
+              <motion.div className="form-row" variants={fadeUp}>
+                <label htmlFor="servicio">Servicio de interés</label>
+                <select id="servicio" name="servicio" defaultValue="">
+                  <option value="" disabled>
+                    Selecciona una opción
+                  </option>
+                  <option value="mantenimiento">Mantenimiento de piscinas</option>
+                  <option value="proyeccion">Piscina proyectada nueva</option>
+                  <option value="reforma">Reforma o impermeabilización</option>
+                  <option value="fontaneria">Fontanería y cloración salina</option>
+                  <option value="otro">Otros trabajos</option>
+                </select>
+              </motion.div>
+              <motion.div className="form-row" variants={fadeUp}>
+                <label htmlFor="mensaje">Cuéntanos más detalles</label>
+                <textarea
+                  id="mensaje"
+                  name="mensaje"
+                  rows="4"
+                  placeholder="Describe el estado de tu piscina y qué necesitas resolver"
+                />
+              </motion.div>
+              <motion.button
                 className="button button--primary"
-                href="#presupuesto"
-                whileHover={{ y: -4, boxShadow: '0 16px 40px rgba(15, 176, 206, 0.55)' }}
-                whileTap={{ scale: 0.96 }}
+                type="submit"
+                variants={fadeUp}
+                whileHover={{ y: -3 }}
+                whileTap={{ scale: 0.97 }}
               >
-                Solicitar presupuesto
-              </motion.a>
-              <motion.a
-                className="button button--ghost"
-                href="#servicios"
-                whileHover={{ y: -4, borderColor: 'rgba(255, 255, 255, 0.65)' }}
-                whileTap={{ scale: 0.96 }}
-              >
-                Ver servicios
-              </motion.a>
-            </motion.div>
-            <motion.div className="hero__badge" variants={fadeUp}>
-              <span className="hero__badge-title">Equipo certificado</span>
-              <span className="hero__badge-text">Más de 250 proyectos entregados con garantía Piscina Moisés.</span>
-            </motion.div>
-          </motion.div>
-          <motion.div className="hero__media" variants={heroContent}>
-            <motion.figure
-              className="hero__photo hero__photo--primary"
-              variants={mediaReveal}
-              whileHover={{ y: -10, scale: 1.02 }}
-            >
-              <motion.img
-                src="https://images.unsplash.com/photo-1534536281715-e28d76689b4d?auto=format&fit=crop&w=1000&q=80"
-                alt="Piscina de lujo al atardecer con iluminación ambiental"
-                loading="lazy"
-              />
-            </motion.figure>
-            <motion.div className="hero__photo-stack" variants={mediaReveal}>
-              <motion.figure className="hero__photo" variants={mediaReveal} whileHover={{ y: -8, scale: 1.02 }}>
-                <motion.img
-                  src="https://images.unsplash.com/photo-1531853121101-1b4b07fd4e9e?auto=format&fit=crop&w=700&q=80"
-                  alt="Detalle de cascada en piscina moderna"
-                  loading="lazy"
-                />
-              </motion.figure>
-              <motion.figure className="hero__photo" variants={mediaReveal} whileHover={{ y: -8, scale: 1.02 }}>
-                <motion.img
-                  src="https://images.unsplash.com/photo-1527515637462-cff94eecc1ac?auto=format&fit=crop&w=700&q=80"
-                  alt="Técnico de piscina realizando comprobaciones de calidad"
-                  loading="lazy"
-                />
-              </motion.figure>
-            </motion.div>
-            <motion.div className="hero__note" variants={fadeUp}>
-              <span>Residencial · Hotelero · Wellness</span>
-              <p>Proyectos personalizados con seguimiento digital desde el diseño hasta el mantenimiento.</p>
-            </motion.div>
-          </motion.div>
-        </motion.div>
-      </motion.section>
+                Enviar solicitud
+              </motion.button>
+            </motion.form>
+            <motion.aside className="contact__info" variants={cardReveal}>
+              <h3>¿Prefieres hablar con nosotros?</h3>
+              <p>Resolvemos dudas técnicas, urgencias y visitas de valoración en menos de 24 horas.</p>
+              <a href="tel:+34911011222">91 101 12 22</a>
+              <a href="mailto:hola@piscinamoises.es">hola@piscinamoises.es</a>
+              <ul>
+                <li>Horario: lunes a sábado de 8:00 a 20:00</li>
+                <li>Servicio de emergencia para comunidades y hoteles</li>
+                <li>Cobertura: Comunidad de Madrid y provincias vecinas</li>
+              </ul>
+            </motion.aside>
+          </div>
+        </motion.section>
 
-      <motion.section className="selling-points" id="servicios" {...inViewConfig} variants={sectionFade}>
-        <motion.div className="section-heading" variants={fadeUp}>
-          <p className="section-eyebrow">Por qué nos eligen</p>
-          <h2>Soluciones integrales y artesanía en cada detalle</h2>
-          <p className="section-description">
-            Somos una empresa española especializada en piscinas a medida. Coordinamos todas las fases del proyecto para que
-            disfrutes sin preocupaciones, con comunicación directa y tiempos de respuesta inmediatos.
-          </p>
-        </motion.div>
-        <div className="selling-points__grid">
-          {sellingPoints.map((point, index) => (
-            <motion.article
-              className="card"
-              key={point.label}
-              variants={cardReveal}
-              custom={index}
-              whileHover={{ y: -10, boxShadow: '0 26px 70px rgba(0, 0, 0, 0.35)' }}
-            >
-              <h3>{point.label}</h3>
-              <p>{point.detail}</p>
-            </motion.article>
-          ))}
-        </div>
-      </motion.section>
-
-      <motion.section className="services" {...inViewConfig} variants={sectionFade}>
-        <motion.div className="section-heading" variants={fadeUp}>
-          <p className="section-eyebrow">Soluciones a medida</p>
-          <h2>Servicios especializados para cada necesidad</h2>
-        </motion.div>
-        <div className="services__grid">
-          {services.map((service, index) => (
-            <motion.article
-              className="service-card"
-              key={service.title}
-              variants={cardReveal}
-              custom={index}
-              whileHover={{ y: -12, scale: 1.01 }}
-            >
-              <div className="service-card__media">
-                <motion.img src={service.image.src} alt={service.image.alt} loading="lazy" />
-              </div>
-              <div className="service-card__content">
-                <h3>{service.title}</h3>
-                <p>{service.description}</p>
-              </div>
-            </motion.article>
-          ))}
-        </div>
-      </motion.section>
-
-      <motion.section className="highlights" {...inViewConfig} variants={sectionFade}>
-        <motion.div className="section-heading" variants={fadeUp}>
-          <p className="section-eyebrow">Nuestra forma de trabajar</p>
-          <h2>Expertos en proyectos complejos y mantenimiento continuo</h2>
-          <p className="section-description">
-            Integramos arquitectura, ingeniería y mantenimiento en un mismo equipo. Cada piscina recibe un plan único con
-            inspecciones programadas, informes digitales y recomendaciones para optimizar recursos.
-          </p>
-        </motion.div>
-        <div className="highlights__grid">
-          {highlights.map((highlight, index) => (
-            <motion.article className="highlight-card" key={highlight.title} variants={cardReveal} custom={index}>
-              <h3>{highlight.title}</h3>
-              <p>{highlight.description}</p>
-            </motion.article>
-          ))}
-        </div>
-      </motion.section>
-
-      <motion.section className="gallery" {...inViewConfig} variants={sectionFade}>
-        <motion.div className="section-heading" variants={fadeUp}>
-          <p className="section-eyebrow">Casos recientes</p>
-          <h2>Inspiración visual de nuestros proyectos</h2>
-          <p className="section-description">
-            Así combinamos estética, ingeniería y mantenimiento profesional en residencias privadas, hoteles y comunidades de
-            vecinos en la zona centro.
-          </p>
-        </motion.div>
-        <div className="gallery__grid">
-          {projects.map((project, index) => (
-            <motion.figure
-              className="gallery__item"
-              key={project.name}
-              variants={cardReveal}
-              custom={index}
-              whileHover={{ y: -10, scale: 1.01 }}
-            >
-              <motion.img src={project.image} alt={project.name} loading="lazy" />
-              <figcaption>
-                <strong>{project.name}</strong>
-                <span>{project.detail}</span>
-              </figcaption>
-            </motion.figure>
-          ))}
-        </div>
-      </motion.section>
-
-      <motion.section className="cta" {...inViewConfig} variants={sectionFade}>
-        <motion.div className="cta__text" variants={fadeUp}>
-          <p className="section-eyebrow">Piscinas impecables todo el año</p>
-          <h2>
-            Mantenimiento continuo
-            <br /> con seguimiento digital
-          </h2>
-          <p>
-            Recibe informes tras cada visita, controla el estado del agua y confía en un plan diseñado para tu piscina. Nos
-            encargamos de todo para que tú solo tengas que disfrutarla.
-          </p>
-        </motion.div>
-        <motion.ul className="cta__list" variants={fadeUp}>
-          {[
-            {
-              title: 'Visitas programadas',
-              detail: 'Calendario adaptado a tu uso, con recordatorios automáticos.'
-            },
-            {
-              title: 'Control químico preciso',
-              detail: 'Mediciones periódicas y ajustes exactos para garantizar seguridad.'
-            },
-            {
-              title: 'Asistencia 24/7',
-              detail: 'Disponibilidad para emergencias con técnicos especializados.'
-            }
-          ].map((item, index) => (
-            <motion.li key={item.title} variants={cardReveal} custom={index}>
-              <strong>{item.title}</strong>
-              <span>{item.detail}</span>
-            </motion.li>
-          ))}
-        </motion.ul>
-      </motion.section>
-
-      <motion.section className="process" {...inViewConfig} variants={sectionFade}>
-        <motion.div className="section-heading" variants={fadeUp}>
-          <p className="section-eyebrow">Así trabajamos</p>
-          <h2>Un proceso claro, eficiente y sin sorpresas</h2>
-        </motion.div>
-        <div className="process__grid">
-          {steps.map((step, index) => (
-            <motion.article className="process-card" key={step.title} variants={cardReveal} custom={index}>
-              <h3>{step.title}</h3>
-              <p>{step.description}</p>
-            </motion.article>
-          ))}
-        </div>
-      </motion.section>
-
-      <motion.section className="contact" id="presupuesto" {...inViewConfig} variants={sectionFade}>
-        <motion.div className="section-heading" variants={fadeUp}>
-          <p className="section-eyebrow">Solicita tu propuesta</p>
-          <h2>Pide un presupuesto personalizado</h2>
-          <p className="section-description">
-            Cuéntanos qué necesita tu piscina y te devolveremos una propuesta en menos de 24 horas.
-          </p>
-        </motion.div>
-        <motion.form className="contact__form" variants={contactReveal}>
-          <motion.div className="form-row" variants={fadeUp}>
-            <label htmlFor="nombre">Nombre y apellidos</label>
-            <input id="nombre" name="nombre" type="text" placeholder="Tu nombre" required />
-          </motion.div>
-          <motion.div className="form-row" variants={fadeUp}>
-            <label htmlFor="email">Correo electrónico</label>
-            <input id="email" name="email" type="email" placeholder="tucorreo@email.com" required />
-          </motion.div>
-          <motion.div className="form-row" variants={fadeUp}>
-            <label htmlFor="telefono">Teléfono</label>
-            <input id="telefono" name="telefono" type="tel" placeholder="Tu teléfono" />
-          </motion.div>
-          <motion.div className="form-row" variants={fadeUp}>
-            <label htmlFor="servicio">Servicio de interés</label>
-            <select id="servicio" name="servicio" defaultValue="">
-              <option value="" disabled>
-                Selecciona una opción
-              </option>
-              <option value="mantenimiento">Mantenimiento de piscinas</option>
-              <option value="proyeccion">Piscina proyectada nueva</option>
-              <option value="reforma">Reforma o impermeabilización</option>
-              <option value="fontaneria">Fontanería y cloración salina</option>
-              <option value="otro">Otros trabajos</option>
-            </select>
-          </motion.div>
-          <motion.div className="form-row" variants={fadeUp}>
-            <label htmlFor="mensaje">Cuéntanos más detalles</label>
-            <textarea
-              id="mensaje"
-              name="mensaje"
-              rows="4"
-              placeholder="Describe el estado de tu piscina y qué necesitas resolver"
-            />
-          </motion.div>
-          <motion.button className="button button--primary" type="submit" variants={fadeUp} whileHover={{ y: -3 }} whileTap={{ scale: 0.97 }}>
-            Enviar solicitud
-          </motion.button>
-        </motion.form>
-      </motion.section>
-
-      <motion.footer className="footer" initial="hidden" whileInView="visible" viewport={{ once: true }} variants={fadeUp}>
-        <div>
-          <strong>Piscina Moisés</strong>
-          <p>Servicio integral · Comunidad de Madrid y provincias colindantes</p>
-        </div>
-        <div className="footer__contact">
-          <a href="tel:+34911011222">91 101 12 22</a>
-          <a href="mailto:hola@piscinamoises.es">hola@piscinamoises.es</a>
-        </div>
-      </motion.footer>
-    </main>
+        <motion.footer className="footer" initial="hidden" whileInView="visible" viewport={{ once: true }} variants={fadeUp}>
+          <div className="footer__inner">
+            <div className="footer__brand">
+              <strong>Piscina Moisés</strong>
+              <p>Construcción, reformas y mantenimiento integral de piscinas.</p>
+            </div>
+            <div className="footer__contact">
+              <a href="tel:+34911011222">91 101 12 22</a>
+              <a href="mailto:hola@piscinamoises.es">hola@piscinamoises.es</a>
+            </div>
+          </div>
+        </motion.footer>
+      </main>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- rework the header, hero and navigation to follow the reference site's structure with an upper contact bar and focused CTAs
- refresh service, gallery and contact sections to highlight value props, add direct-contact details and streamline mobile scrolling
- rebuild the global styling palette with light blues, glassy cards and responsive tweaks so the layout matches the requested aesthetic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd8e714cdc8332adfbdb487721c9f4